### PR TITLE
feat: add sqlite license cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ security-checker vuln /path/to/your/project
 
 ## Configuration
 
+### License Cache
+
+To cache license lookups between runs, set the SQLite database path via the
+`LICENSE_CACHE_DB_PATH` environment variable. If not set, a file named
+`license_cache.sqlite` will be created in the current working directory.
+
+```bash
+export LICENSE_CACHE_DB_PATH="/tmp/license_cache.sqlite"
+```
+
 ### Slack Notifications
 
 To use Slack notifications, set the following environment variables:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "security-checker"
-version = "0.2.2"
+version = "0.2.3"
 description = "A comprehensive command-line tool to check security-related issues in your projects, including vulnerability scanning and license compliance checking."
 authors = [
     { name = "Ja-sonYun", email = "killa30867@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "aiohttp>=3.12.12",
     "gitpython>=3.1.44",
     "tenacity>=9.1.2",
+    "semantic-version>=2.10.0",
+    "packaging>=25.0",
 ]
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic-settings>=2.9.1",
     "slack-sdk>=3.35.0",
     "aiohttp>=3.12.12",
+    "aiosqlite>=0.20.0",
     "gitpython>=3.1.44",
     "tenacity>=9.1.2",
     "semantic-version>=2.10.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -61,6 +61,8 @@ multidict==6.4.4
     # via yarl
 openai==1.86.0
     # via security-checker
+packaging==25.0
+    # via security-checker
 propcache==0.3.2
     # via aiohttp
     # via yarl
@@ -84,6 +86,8 @@ pyyaml==6.0.2
 rich==14.0.0
     # via security-checker
 ruff==0.11.13
+semantic-version==2.10.0
+    # via security-checker
 slack-sdk==3.35.0
     # via security-checker
 smmap==5.0.2

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -16,6 +16,8 @@ aiohttp==3.12.12
     # via security-checker
 aiosignal==1.3.2
     # via aiohttp
+aiosqlite==0.20.0
+    # via security-checker
 annotated-types==0.7.0
     # via pydantic
 anyio==4.9.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -61,6 +61,8 @@ multidict==6.4.4
     # via yarl
 openai==1.86.0
     # via security-checker
+packaging==25.0
+    # via security-checker
 propcache==0.3.2
     # via aiohttp
     # via yarl
@@ -82,6 +84,8 @@ python-dotenv==1.1.0
 pyyaml==6.0.2
     # via security-checker
 rich==14.0.0
+    # via security-checker
+semantic-version==2.10.0
     # via security-checker
 slack-sdk==3.35.0
     # via security-checker

--- a/requirements.lock
+++ b/requirements.lock
@@ -16,6 +16,8 @@ aiohttp==3.12.12
     # via security-checker
 aiosignal==1.3.2
     # via aiohttp
+aiosqlite==0.20.0
+    # via security-checker
 annotated-types==0.7.0
     # via pydantic
 anyio==4.9.0

--- a/src/security_checker/checkers/licenses/_cache.py
+++ b/src/security_checker/checkers/licenses/_cache.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import aiosqlite
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class LicenseCacheSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="")
+
+    license_cache_db_path: Path = Field(
+        default=Path("license_cache.sqlite"),
+        description="Path to the SQLite database for license cache.",
+    )
+
+
+class LicenseCache:
+    """Simple SQLite backed cache for package license lookups."""
+
+    def __init__(self, settings: LicenseCacheSettings | None = None) -> None:
+        self.settings = settings or LicenseCacheSettings()
+        self.db_path = self.settings.license_cache_db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn: aiosqlite.Connection | None = None
+
+    async def _create_table(self) -> None:
+        assert self._conn is not None
+        await self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS licenses (
+                package TEXT NOT NULL,
+                version TEXT NOT NULL,
+                license TEXT NOT NULL,
+                PRIMARY KEY (package, version)
+            )
+            """
+        )
+        await self._conn.commit()
+
+    async def get(self, package: str, version: str) -> str | None:
+        assert self._conn is not None
+        async with self._conn.execute(
+            "SELECT license FROM licenses WHERE package = ? AND version = ?",
+            (package, version),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return row[0] if row else None
+
+    async def set(self, package: str, version: str, license: str) -> None:
+        assert self._conn is not None
+        await self._conn.execute(
+            "INSERT OR REPLACE INTO licenses(package, version, license) VALUES (?, ?, ?)",
+            (package, version, license),
+        )
+        await self._conn.commit()
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            await self._conn.close()
+            self._conn = None
+
+    async def __aenter__(self) -> "LicenseCache":
+        self._conn = await aiosqlite.connect(self.db_path)
+        await self._create_table()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()

--- a/src/security_checker/checkers/licenses/_vendor_trait.py
+++ b/src/security_checker/checkers/licenses/_vendor_trait.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import TypeGuard
 
 from security_checker.checkers._base import LockFileBaseTrait
+from security_checker.checkers.licenses._cache import LicenseCache
 from security_checker.checkers.licenses._models import PackageLicense
 from security_checker.vendors._base import VendorBase
 from security_checker.vendors._models import Dependency
@@ -16,23 +17,37 @@ class LicenseCheckerTrait(VendorBase, LockFileBaseTrait):
     async def query_licenses(
         self, packages: Sequence[Dependency]
     ) -> Sequence[PackageLicense]:
-        tasks = [
-            self.query_license(
-                package.name,
-                package.version,
-            )
-            for package in packages
-        ]
-        licenses = await asyncio.gather(*tasks)
+        async with LicenseCache() as cache:
+            results: list[PackageLicense | None] = [None] * len(packages)
+            to_fetch: list[Dependency] = []
+            to_fetch_idx: list[int] = []
 
-        return [
-            PackageLicense(
-                name=package.name,
-                version=package.version,
-                license=license_info,
-            )
-            for package, license_info in zip(packages, licenses)
-        ]
+            for idx, package in enumerate(packages):
+                cached = await cache.get(package.name, package.version)
+                if cached is not None:
+                    results[idx] = PackageLicense(
+                        name=package.name,
+                        version=package.version,
+                        license=cached,
+                    )
+                else:
+                    to_fetch.append(package)
+                    to_fetch_idx.append(idx)
+
+            if to_fetch:
+                tasks = [
+                    self.query_license(pkg.name, pkg.version) for pkg in to_fetch
+                ]
+                licenses = await asyncio.gather(*tasks)
+                for pkg, license_info, idx in zip(to_fetch, licenses, to_fetch_idx):
+                    await cache.set(pkg.name, pkg.version, license_info)
+                    results[idx] = PackageLicense(
+                        name=pkg.name,
+                        version=pkg.version,
+                        license=license_info,
+                    )
+
+            return [res for res in results if res is not None]
 
 
 def is_license_checker_trait(obj: type | None) -> TypeGuard[type[LicenseCheckerTrait]]:

--- a/src/security_checker/checkers/vulnerabilities/_vendor_trait.py
+++ b/src/security_checker/checkers/vulnerabilities/_vendor_trait.py
@@ -21,6 +21,9 @@ class VulnerabilityCheckerTrait(VendorBase, LockFileBaseTrait):
         version: str,
     ) -> VulnerablePackage: ...
 
+    @abstractmethod
+    def is_in_version_range(self, version: str, version_range: str) -> bool: ...
+
     async def scan_dependencies_for_vulnerabilities(
         self, packages: Sequence[Dependency]
     ) -> Sequence[VulnerablePackage]:

--- a/src/security_checker/vendors/registries/npm.py
+++ b/src/security_checker/vendors/registries/npm.py
@@ -2,9 +2,11 @@ import asyncio
 import os
 
 import httpx
+from semantic_version import NpmSpec, Version
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from security_checker.checkers.licenses._vendor_trait import LicenseCheckerTrait
+from security_checker.vendors._models import Dependency
 from security_checker.vendors.registries.github_security_advisory import (
     GithubSecurityAdvisoryRegistry,
 )
@@ -70,3 +72,7 @@ class NpmJSRegistry(LicenseCheckerTrait, GithubSecurityAdvisoryRegistry):
                         license_info = licenses[0]
 
             return license_info if license_info else "UNKNOWN"
+
+    def is_in_version_range(self, version: str, version_range: str) -> bool:
+        spec = NpmSpec(version_range)
+        return Version(version) in spec

--- a/src/security_checker/vendors/registries/pypi.py
+++ b/src/security_checker/vendors/registries/pypi.py
@@ -2,6 +2,8 @@ import asyncio
 import os
 
 import httpx
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from security_checker.checkers.licenses._vendor_trait import LicenseCheckerTrait
@@ -84,3 +86,7 @@ class PyPiRegistry(LicenseCheckerTrait, GithubSecurityAdvisoryRegistry):
                 license_info = package_info.get("license_expression", None)
 
             return license_info if license_info else "UNKNOWN"
+
+    def is_in_version_range(self, version: str, version_range: str) -> bool:
+        spec = SpecifierSet(version_range.replace(" ", ""))
+        return Version(version) in spec

--- a/vulnerability_checker_results.md
+++ b/vulnerability_checker_results.md
@@ -1,0 +1,9841 @@
+# Vulnerability Checker Results
+
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - `setuptools` (`70.0.0`)
+   - Vulnerability ID: CVE-2025-47273
+   - Severity: HIGH
+   - Description: setuptools has a path traversal vulnerability in PackageIndex.download that leads to Arbitrary File Write
+   - Published Date: 2025-05-19 16:52:43+00:00
+   - Version Range: < 78.1.1
+   - Reference URL: https://github.com/pypa/setuptools/security/advisories/GHSA-5rjg-fvgr-3xxf
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+### Moderate Vulnerabilities (Review Recommended)
+ - `requests` (`2.32.3`)
+   - Vulnerability ID: CVE-2024-47081
+   - Severity: MODERATE
+   - Description: Requests vulnerable to .netrc credentials leak via malicious URLs
+   - Published Date: 2025-06-09 19:06:08+00:00
+   - Version Range: < 2.32.4
+   - Reference URL: https://github.com/psf/requests/security/advisories/GHSA-9hjg-9r4m-mvj7
+### Low Vulnerabilities (Monitor)
+ - `certifi` (`2024.6.2`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+ - `configobj` (`5.0.8`)
+   - Vulnerability ID: CVE-2023-26112
+   - Severity: LOW
+   - Description: configobj ReDoS exploitable by developer using values in a server-side configuration file
+   - Published Date: 2023-04-03 06:30:19+00:00
+   - Version Range: < 5.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26112
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.9-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.9-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.9-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.9-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.9-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.9-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_processor/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_processor/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_processor_eventbridge.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_processor_eventbridge.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/inference/.terraform/modules/smi_inference.smi_endpoints.smi_scheduling.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/inference/.terraform/modules/smi_inference.smi_endpoints.smi_scheduling.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.9-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.9-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/modules/inference/.terraform/modules/smi_scheduling.lambda/examples/fixtures/python-app-src-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/modules/inference/.terraform/modules/smi_scheduling.lambda/examples/fixtures/python-app-poetry`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/core`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `scikit-learn` (`1.4.2`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/core/module`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - `tornado` (`6.4`)
+   - Vulnerability ID: CVE-2025-47287
+   - Severity: HIGH
+   - Description: Tornado vulnerable to excessive logging caused by malformed multipart form data
+   - Published Date: 2025-05-16 14:12:40+00:00
+   - Version Range: < 6.5
+   - Reference URL: https://github.com/tornadoweb/tornado/security/advisories/GHSA-7cx3-6m66-7c5m
+ - `tornado` (`6.4`)
+   - Vulnerability ID: CVE-2024-52804
+   - Severity: HIGH
+   - Description: Tornado has an HTTP cookie parsing DoS vulnerability
+   - Published Date: 2024-11-22 20:26:41+00:00
+   - Version Range: <= 6.4.1
+   - Reference URL: https://github.com/tornadoweb/tornado/security/advisories/GHSA-8w49-h785-mj3c
+ - `tqdm` (`4.66.1`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.1`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `pycryptodome` (`3.19.0`)
+   - Vulnerability ID: CVE-2023-52323
+   - Severity: HIGH
+   - Description: PyCryptodome and pycryptodomex side-channel leakage for OAEP decryption
+   - Published Date: 2024-01-05 06:30:19+00:00
+   - Version Range: < 3.19.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-52323
+ - `setuptools` (`69.0.2`)
+   - Vulnerability ID: CVE-2025-47273
+   - Severity: HIGH
+   - Description: setuptools has a path traversal vulnerability in PackageIndex.download that leads to Arbitrary File Write
+   - Published Date: 2025-05-19 16:52:43+00:00
+   - Version Range: < 78.1.1
+   - Reference URL: https://github.com/pypa/setuptools/security/advisories/GHSA-5rjg-fvgr-3xxf
+ - `setuptools` (`69.0.2`)
+   - Vulnerability ID: CVE-2024-6345
+   - Severity: HIGH
+   - Description: setuptools vulnerable to Command Injection via package URL
+   - Published Date: 2024-07-15 03:30:57+00:00
+   - Version Range: < 70.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-6345
+ - `jupyter-lsp` (`2.2.1`)
+   - Vulnerability ID: CVE-2024-22415
+   - Severity: HIGH
+   - Description: Unsecured endpoints in the jupyter-lsp server extension
+   - Published Date: 2024-01-18 16:12:28+00:00
+   - Version Range: <= 2.2.1
+   - Reference URL: https://github.com/jupyter-lsp/jupyterlab-lsp/security/advisories/GHSA-4qhp-652w-c22x
+ - `jupyter-server` (`2.12.0`)
+   - Vulnerability ID: CVE-2022-29241
+   - Severity: HIGH
+   - Description: Jupyter server Token bruteforcing
+   - Published Date: 2022-06-16 23:13:57+00:00
+   - Version Range: = 2.0.0a0
+   - Reference URL: https://github.com/jupyter-server/jupyter_server/security/advisories/GHSA-q874-g24w-4q9g
+ - `jupyterlab` (`4.0.9`)
+   - Vulnerability ID: CVE-2024-43805
+   - Severity: HIGH
+   - Description: HTML injection in Jupyter Notebook and JupyterLab leading to DOM Clobbering
+   - Published Date: 2024-08-29 17:55:53+00:00
+   - Version Range: >= 4.0.0, <= 4.2.4
+   - Reference URL: https://github.com/jupyterlab/jupyterlab/security/advisories/GHSA-9q39-rmj3-p4r2
+ - `jupyterlab` (`4.0.9`)
+   - Vulnerability ID: CVE-2024-22421
+   - Severity: HIGH
+   - Description: JupyterLab vulnerable to potential authentication and CSRF tokens leak
+   - Published Date: 2024-01-19 20:28:10+00:00
+   - Version Range: >= 4.0.0, <= 4.0.10
+   - Reference URL: https://github.com/jupyterlab/jupyterlab/security/advisories/GHSA-44cc-43rp-5947
+ - `orjson` (`3.9.10`)
+   - Vulnerability ID: CVE-2024-27454
+   - Severity: HIGH
+   - Description: orjson does not limit recursion for deeply nested JSON documents
+   - Published Date: 2024-02-26 18:30:31+00:00
+   - Version Range: < 3.9.15
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-27454
+### Moderate Vulnerabilities (Review Recommended)
+ - `tornado` (`6.4`)
+   - Vulnerability ID: GHSA-w235-7p84-xx57
+   - Severity: MODERATE
+   - Description: Tornado has a CRLF injection in CurlAsyncHTTPClient headers
+   - Published Date: 2024-06-06 21:46:31+00:00
+   - Version Range: <= 6.4.0
+   - Reference URL: https://github.com/tornadoweb/tornado/security/advisories/GHSA-w235-7p84-xx57
+ - `tornado` (`6.4`)
+   - Vulnerability ID: GHSA-753j-mpmx-qq6g
+   - Severity: MODERATE
+   - Description: Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling') in tornado
+   - Published Date: 2024-06-06 21:41:20+00:00
+   - Version Range: <= 6.4.0
+   - Reference URL: https://github.com/tornadoweb/tornado/security/advisories/GHSA-753j-mpmx-qq6g
+ - `black` (`23.11.0`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `idna` (`3.6`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `jinja2` (`3.1.2`)
+   - Vulnerability ID: CVE-2025-27516
+   - Severity: MODERATE
+   - Description: Jinja2 vulnerable to sandbox breakout through attr filter selecting format method
+   - Published Date: 2025-03-05 20:40:14+00:00
+   - Version Range: <= 3.1.5
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-cpwx-vrp4-4pq7
+ - `jinja2` (`3.1.2`)
+   - Vulnerability ID: CVE-2024-56201
+   - Severity: MODERATE
+   - Description: Jinja has a sandbox breakout through malicious filenames
+   - Published Date: 2024-12-23 17:54:12+00:00
+   - Version Range: >= 3.0.0, <= 3.1.4
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-gmj6-6f8f-6699
+ - `jinja2` (`3.1.2`)
+   - Vulnerability ID: CVE-2024-56326
+   - Severity: MODERATE
+   - Description: Jinja has a sandbox breakout through indirect reference to format method
+   - Published Date: 2024-12-23 17:56:08+00:00
+   - Version Range: <= 3.1.4
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h
+ - `jinja2` (`3.1.2`)
+   - Vulnerability ID: CVE-2024-34064
+   - Severity: MODERATE
+   - Description: Jinja vulnerable to HTML attribute injection when passing user input as keys to xmlattr filter
+   - Published Date: 2024-05-06 14:20:59+00:00
+   - Version Range: < 3.1.4
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-h75v-3vvj-5mfj
+ - `jinja2` (`3.1.2`)
+   - Vulnerability ID: CVE-2024-22195
+   - Severity: MODERATE
+   - Description: Jinja vulnerable to HTML attribute injection when passing user input as keys to xmlattr filter
+   - Published Date: 2024-01-11 15:20:48+00:00
+   - Version Range: < 3.1.3
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-h5c8-rqwp-cp95
+ - `pypdf2` (`3.0.1`)
+   - Vulnerability ID: CVE-2023-36807
+   - Severity: MODERATE
+   - Description: PyPDF2 vulnerable to possible Infinite Loop when reading malformed objects
+   - Published Date: 2023-06-30 22:19:39+00:00
+   - Version Range: = 2.10.5
+   - Reference URL: https://github.com/py-pdf/pypdf/security/advisories/GHSA-hm9v-vj3r-r55m
+ - `pypdf2` (`3.0.1`)
+   - Vulnerability ID: CVE-2023-36464
+   - Severity: MODERATE
+   - Description: pypdf and PyPDF2 possible Infinite Loop when a comment isn't followed by a character
+   - Published Date: 2023-06-30 20:33:57+00:00
+   - Version Range: >= 2.2.0, <= 3.0.1
+   - Reference URL: https://github.com/py-pdf/pypdf/security/advisories/GHSA-4vvm-4w3v-6mr8
+ - `requests` (`2.31.0`)
+   - Vulnerability ID: CVE-2024-47081
+   - Severity: MODERATE
+   - Description: Requests vulnerable to .netrc credentials leak via malicious URLs
+   - Published Date: 2025-06-09 19:06:08+00:00
+   - Version Range: < 2.32.4
+   - Reference URL: https://github.com/psf/requests/security/advisories/GHSA-9hjg-9r4m-mvj7
+ - `requests` (`2.31.0`)
+   - Vulnerability ID: CVE-2024-35195
+   - Severity: MODERATE
+   - Description: Requests `Session` object does not verify requests after making first request with verify=False
+   - Published Date: 2024-05-20 20:15:00+00:00
+   - Version Range: < 2.32.0
+   - Reference URL: https://github.com/psf/requests/security/advisories/GHSA-9wx4-h78v-vm56
+ - `scikit-learn` (`1.3.2`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `jupyterlab` (`4.0.9`)
+   - Vulnerability ID: CVE-2024-22420
+   - Severity: MODERATE
+   - Description: JupyterLab vulnerable to SXSS in Markdown Preview
+   - Published Date: 2024-01-19 20:24:09+00:00
+   - Version Range: >= 4.0.0, <= 4.0.10
+   - Reference URL: https://github.com/jupyterlab/jupyterlab/security/advisories/GHSA-4m77-cmpx-vjc4
+### Low Vulnerabilities (Monitor)
+ - `tqdm` (`4.66.1`)
+   - Vulnerability ID: CVE-2024-34062
+   - Severity: LOW
+   - Description: tqdm CLI arguments injection attack
+   - Published Date: 2024-05-03 19:33:28+00:00
+   - Version Range: >= 4.4.0, < 4.66.3
+   - Reference URL: https://github.com/tqdm/tqdm/security/advisories/GHSA-g7vv-2v7x-gj9p
+ - `certifi` (`2023.11.17`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+ - `configobj` (`5.0.8`)
+   - Vulnerability ID: CVE-2023-26112
+   - Severity: LOW
+   - Description: configobj ReDoS exploitable by developer using values in a server-side configuration file
+   - Published Date: 2023-04-03 06:30:19+00:00
+   - Version Range: < 5.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26112
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/core/module/mlops-modules/sagemaker-studio/slack-app-integrations`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+### High Vulnerabilities (Action Recommended)
+ - `fastapi` (`0.104.1`)
+   - Vulnerability ID: GHSA-qf9m-vfgh-m389
+   - Severity: HIGH
+   - Description: Duplicate Advisory: FastAPI Content-Type Header ReDoS
+   - Published Date: 2024-02-05 17:01:54+00:00
+   - Version Range: <= 0.109.0
+   - Reference URL: https://github.com/tiangolo/fastapi/security/advisories/GHSA-qf9m-vfgh-m389
+ - `gitpython` (`3.1.40`)
+   - Vulnerability ID: CVE-2024-22190
+   - Severity: HIGH
+   - Description: Untrusted search path under some conditions on Windows allows arbitrary code execution
+   - Published Date: 2024-01-10 15:46:00+00:00
+   - Version Range: < 3.1.41
+   - Reference URL: https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-2mqj-m65w-jghx
+ - `starlette` (`0.27.0`)
+   - Vulnerability ID: CVE-2024-47874
+   - Severity: HIGH
+   - Description: Starlette Denial of service (DoS) via multipart/form-data
+   - Published Date: 2024-10-15 18:12:57+00:00
+   - Version Range: < 0.40.0
+   - Reference URL: https://github.com/encode/starlette/security/advisories/GHSA-f96h-pmfr-66vw
+ - `starlette` (`0.27.0`)
+   - Vulnerability ID: GHSA-93gm-qmq6-w238
+   - Severity: HIGH
+   - Description: Duplicate Advisory: Starlette Content-Type Header ReDoS
+   - Published Date: 2024-02-05 17:01:19+00:00
+   - Version Range: <= 0.36.1
+   - Reference URL: https://github.com/encode/starlette/security/advisories/GHSA-93gm-qmq6-w238
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.11.0`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `idna` (`3.4`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `urllib3` (`2.0.7`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/api`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+### High Vulnerabilities (Action Recommended)
+ - `python-multipart` (`0.0.17`)
+   - Vulnerability ID: CVE-2024-53981
+   - Severity: HIGH
+   - Description: Denial of service (DoS) via deformation `multipart/form-data` boundary
+   - Published Date: 2024-12-02 21:37:04+00:00
+   - Version Range: < 0.0.18
+   - Reference URL: https://github.com/Kludex/python-multipart/security/advisories/GHSA-59g5-xgcq-4qw3
+ - `starlette` (`0.37.2`)
+   - Vulnerability ID: CVE-2024-47874
+   - Severity: HIGH
+   - Description: Starlette Denial of service (DoS) via multipart/form-data
+   - Published Date: 2024-10-15 18:12:57+00:00
+   - Version Range: < 0.40.0
+   - Reference URL: https://github.com/encode/starlette/security/advisories/GHSA-f96h-pmfr-66vw
+### Moderate Vulnerabilities (Review Recommended)
+ - `pypdf2` (`3.0.1`)
+   - Vulnerability ID: CVE-2023-36807
+   - Severity: MODERATE
+   - Description: PyPDF2 vulnerable to possible Infinite Loop when reading malformed objects
+   - Published Date: 2023-06-30 22:19:39+00:00
+   - Version Range: = 2.10.5
+   - Reference URL: https://github.com/py-pdf/pypdf/security/advisories/GHSA-hm9v-vj3r-r55m
+ - `pypdf2` (`3.0.1`)
+   - Vulnerability ID: CVE-2023-36464
+   - Severity: MODERATE
+   - Description: pypdf and PyPDF2 possible Infinite Loop when a comment isn't followed by a character
+   - Published Date: 2023-06-30 20:33:57+00:00
+   - Version Range: >= 2.2.0, <= 3.0.1
+   - Reference URL: https://github.com/py-pdf/pypdf/security/advisories/GHSA-4vvm-4w3v-6mr8
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `cryptography` (`42.0.8`)
+   - Vulnerability ID: GHSA-h4gh-qq45-vh27
+   - Severity: MODERATE
+   - Description: pyca/cryptography has a vulnerable OpenSSL included in cryptography wheels
+   - Published Date: 2024-09-03 21:59:48+00:00
+   - Version Range: >= 37.0.0, < 43.0.1
+   - Reference URL: https://github.com/pyca/cryptography/security/advisories/GHSA-h4gh-qq45-vh27
+ - `jinja2` (`3.1.4`)
+   - Vulnerability ID: CVE-2025-27516
+   - Severity: MODERATE
+   - Description: Jinja2 vulnerable to sandbox breakout through attr filter selecting format method
+   - Published Date: 2025-03-05 20:40:14+00:00
+   - Version Range: <= 3.1.5
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-cpwx-vrp4-4pq7
+ - `jinja2` (`3.1.4`)
+   - Vulnerability ID: CVE-2024-56201
+   - Severity: MODERATE
+   - Description: Jinja has a sandbox breakout through malicious filenames
+   - Published Date: 2024-12-23 17:54:12+00:00
+   - Version Range: >= 3.0.0, <= 3.1.4
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-gmj6-6f8f-6699
+ - `jinja2` (`3.1.4`)
+   - Vulnerability ID: CVE-2024-56326
+   - Severity: MODERATE
+   - Description: Jinja has a sandbox breakout through indirect reference to format method
+   - Published Date: 2024-12-23 17:56:08+00:00
+   - Version Range: <= 3.1.4
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h
+### Low Vulnerabilities (Monitor)
+ - `pyjwt` (`2.9.0`)
+   - Vulnerability ID: CVE-2024-53861
+   - Severity: LOW
+   - Description: PyJWT Issuer field partial matches allowed
+   - Published Date: 2024-12-02 18:34:11+00:00
+   - Version Range: = 2.10.0
+   - Reference URL: https://github.com/jpadilla/pyjwt/security/advisories/GHSA-75c5-xw7c-p5pm
+ - `cryptography` (`42.0.8`)
+   - Vulnerability ID: CVE-2024-12797
+   - Severity: LOW
+   - Description: Vulnerable OpenSSL included in cryptography wheels
+   - Published Date: 2025-02-11 18:06:42+00:00
+   - Version Range: >= 42.0.0, < 44.0.1
+   - Reference URL: https://github.com/pyca/cryptography/security/advisories/GHSA-79v4-65xg-pq4g
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/artifacts/direct-item-code-recognition_202504240811.tar`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+### High Vulnerabilities (Action Recommended)
+ - `tqdm` (`4.67.1`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.67.1`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/artifacts/text-recognition_202503121612.tar`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+### High Vulnerabilities (Action Recommended)
+ - `tornado` (`6.4.2`)
+   - Vulnerability ID: CVE-2025-47287
+   - Severity: HIGH
+   - Description: Tornado vulnerable to excessive logging caused by malformed multipart form data
+   - Published Date: 2025-05-16 14:12:40+00:00
+   - Version Range: < 6.5
+   - Reference URL: https://github.com/tornadoweb/tornado/security/advisories/GHSA-7cx3-6m66-7c5m
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+### Low Vulnerabilities (Monitor)
+ - `certifi` (`2024.2.2`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/extract-pdf-specification`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `scikit-learn` (`1.4.2`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/predict-drawing-pages`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+### High Vulnerabilities (Action Recommended)
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `scikit-learn` (`1.4.2`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+### Low Vulnerabilities (Monitor)
+ - `certifi` (`2024.2.2`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/text-recognition`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+### High Vulnerabilities (Action Recommended)
+ - `tornado` (`6.4.2`)
+   - Vulnerability ID: CVE-2025-47287
+   - Severity: HIGH
+   - Description: Tornado vulnerable to excessive logging caused by malformed multipart form data
+   - Published Date: 2025-05-16 14:12:40+00:00
+   - Version Range: < 6.5
+   - Reference URL: https://github.com/tornadoweb/tornado/security/advisories/GHSA-7cx3-6m66-7c5m
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+### Low Vulnerabilities (Monitor)
+ - `certifi` (`2024.2.2`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/cell-recognition`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/direct-item-code-recognition`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+### High Vulnerabilities (Action Recommended)
+ - `tqdm` (`4.67.1`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.67.1`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/appliance-style-classification`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `scikit-learn` (`1.4.2`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/text-label-classification`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - `scikit-learn` (`1.4.2`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/figure-detection`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `torch` (`2.3.0`)
+   - Vulnerability ID: CVE-2025-32434
+   - Severity: CRITICAL
+   - Description: PyTorch: `torch.load` with `weights_only=True` leads to remote code execution
+   - Published Date: 2025-04-18 15:19:28+00:00
+   - Version Range: <= 2.5.1
+   - Reference URL: https://github.com/pytorch/pytorch/security/advisories/GHSA-53q9-r3pm-6pq6
+ - `torch` (`2.3.0`)
+   - Vulnerability ID: CVE-2024-7804
+   - Severity: CRITICAL
+   - Description: Withdrawn Advisory: PyTorch deserialization vulnerability
+   - Published Date: 2025-03-20 12:32:46+00:00
+   - Version Range: <= 2.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-7804
+### High Vulnerabilities (Action Recommended)
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.4`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+### Moderate Vulnerabilities (Review Recommended)
+ - `requests` (`2.31.0`)
+   - Vulnerability ID: CVE-2024-47081
+   - Severity: MODERATE
+   - Description: Requests vulnerable to .netrc credentials leak via malicious URLs
+   - Published Date: 2025-06-09 19:06:08+00:00
+   - Version Range: < 2.32.4
+   - Reference URL: https://github.com/psf/requests/security/advisories/GHSA-9hjg-9r4m-mvj7
+ - `requests` (`2.31.0`)
+   - Vulnerability ID: CVE-2024-35195
+   - Severity: MODERATE
+   - Description: Requests `Session` object does not verify requests after making first request with verify=False
+   - Published Date: 2024-05-20 20:15:00+00:00
+   - Version Range: < 2.32.0
+   - Reference URL: https://github.com/psf/requests/security/advisories/GHSA-9wx4-h78v-vm56
+ - `scikit-learn` (`1.4.2`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `torch` (`2.3.0`)
+   - Vulnerability ID: CVE-2025-3730
+   - Severity: MODERATE
+   - Description: PyTorch Improper Resource Shutdown or Release vulnerability
+   - Published Date: 2025-04-16 21:30:59+00:00
+   - Version Range: <= 2.7.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-3730
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `jinja2` (`3.1.4`)
+   - Vulnerability ID: CVE-2025-27516
+   - Severity: MODERATE
+   - Description: Jinja2 vulnerable to sandbox breakout through attr filter selecting format method
+   - Published Date: 2025-03-05 20:40:14+00:00
+   - Version Range: <= 3.1.5
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-cpwx-vrp4-4pq7
+ - `jinja2` (`3.1.4`)
+   - Vulnerability ID: CVE-2024-56201
+   - Severity: MODERATE
+   - Description: Jinja has a sandbox breakout through malicious filenames
+   - Published Date: 2024-12-23 17:54:12+00:00
+   - Version Range: >= 3.0.0, <= 3.1.4
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-gmj6-6f8f-6699
+ - `jinja2` (`3.1.4`)
+   - Vulnerability ID: CVE-2024-56326
+   - Severity: MODERATE
+   - Description: Jinja has a sandbox breakout through indirect reference to format method
+   - Published Date: 2024-12-23 17:56:08+00:00
+   - Version Range: <= 3.1.4
+   - Reference URL: https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h
+### Low Vulnerabilities (Monitor)
+ - `torch` (`2.3.0`)
+   - Vulnerability ID: CVE-2025-2953
+   - Severity: LOW
+   - Description: PyTorch susceptible to local Denial of Service
+   - Published Date: 2025-03-30 18:30:24+00:00
+   - Version Range: < 2.7.1-rc1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-2953
+ - `certifi` (`2024.2.2`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/predict-candidate-item-codes`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - `black` (`23.12.1`)
+   - Vulnerability ID: CVE-2024-21503
+   - Severity: MODERATE
+   - Description: Black vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-03-19 06:30:52+00:00
+   - Version Range: >= 0, < 24.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21503
+ - `scikit-learn` (`1.4.2`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/frontend`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `eslint-scope` (`7.2.2`)
+   - Vulnerability ID: GHSA-hxxf-q3w9-4xgw
+   - Severity: CRITICAL
+   - Description: Malicious Package in eslint-scope
+   - Published Date: 2018-07-12 19:52:02+00:00
+   - Version Range: = 3.7.2
+   - Reference URL: https://github.com/eslint/eslint-scope/issues/39
+ - `fsevents` (`2.3.3`)
+   - Vulnerability ID: CVE-2023-45311
+   - Severity: CRITICAL
+   - Description: Code injection in fsevents
+   - Published Date: 2023-10-06 21:30:49+00:00
+   - Version Range: <= 1.2.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-45311
+ - `@babel/traverse` (`7.26.5`)
+   - Vulnerability ID: CVE-2023-45133
+   - Severity: CRITICAL
+   - Description: Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code
+   - Published Date: 2023-10-16 13:55:36+00:00
+   - Version Range: >= 8.0.0-alpha.0, < 8.0.0-alpha.4
+   - Reference URL: https://github.com/babel/babel/security/advisories/GHSA-67hx-6x53-jw92
+ - `@babel/traverse` (`7.26.5`)
+   - Vulnerability ID: CVE-2023-45133
+   - Severity: CRITICAL
+   - Description: Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code
+   - Published Date: 2023-10-16 13:55:36+00:00
+   - Version Range: < 7.23.2
+   - Reference URL: https://github.com/babel/babel/security/advisories/GHSA-67hx-6x53-jw92
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: CVE-2019-19919
+   - Severity: CRITICAL
+   - Description: Prototype Pollution in handlebars
+   - Published Date: 2019-12-26 17:58:13+00:00
+   - Version Range: < 3.0.8
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-19919
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: CVE-2019-19919
+   - Severity: CRITICAL
+   - Description: Prototype Pollution in handlebars
+   - Published Date: 2019-12-26 17:58:13+00:00
+   - Version Range: >= 4.0.0, < 4.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-19919
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: CVE-2021-23383
+   - Severity: CRITICAL
+   - Description: Prototype Pollution in handlebars
+   - Published Date: 2022-02-10 23:51:42+00:00
+   - Version Range: < 4.7.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23383
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: CVE-2021-23369
+   - Severity: CRITICAL
+   - Description: Remote code execution in handlebars when compiling templates
+   - Published Date: 2021-05-06 15:57:44+00:00
+   - Version Range: < 4.7.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23369
+ - `https-proxy-agent` (`7.0.6`)
+   - Vulnerability ID: CVE-2018-3739
+   - Severity: CRITICAL
+   - Description: Denial of Service in https-proxy-agent
+   - Published Date: 2018-07-27 17:04:52+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-3736
+ - `https-proxy-agent` (`5.0.1`)
+   - Vulnerability ID: CVE-2018-3739
+   - Severity: CRITICAL
+   - Description: Denial of Service in https-proxy-agent
+   - Published Date: 2018-07-27 17:04:52+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-3736
+ - `js-yaml` (`4.1.0`)
+   - Vulnerability ID: CVE-2013-4660
+   - Severity: CRITICAL
+   - Description: Deserialization Code Execution in js-yaml
+   - Published Date: 2017-10-24 18:33:37+00:00
+   - Version Range: < 2.0.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4660
+ - `minimist` (`1.2.8`)
+   - Vulnerability ID: CVE-2021-44906
+   - Severity: CRITICAL
+   - Description: Prototype Pollution in minimist
+   - Published Date: 2022-03-18 00:01:09+00:00
+   - Version Range: < 0.2.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-44906
+ - `minimist` (`1.2.8`)
+   - Vulnerability ID: CVE-2021-44906
+   - Severity: CRITICAL
+   - Description: Prototype Pollution in minimist
+   - Published Date: 2022-03-18 00:01:09+00:00
+   - Version Range: >= 1.0.0, < 1.2.6
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-44906
+ - `swiper` (`11.1.1`)
+   - Vulnerability ID: CVE-2021-23370
+   - Severity: CRITICAL
+   - Description: Prototype Pollution in swiper
+   - Published Date: 2021-05-10 15:36:30+00:00
+   - Version Range: < 6.5.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23370
+ - `thenify` (`3.3.1`)
+   - Vulnerability ID: CVE-2020-7677
+   - Severity: CRITICAL
+   - Description: thenify before 3.3.1 made use of unsafe calls to `eval`.
+   - Published Date: 2022-07-18 19:15:29+00:00
+   - Version Range: < 3.3.1
+   - Reference URL: https://github.com/thenables/thenify/issues/29
+ - `uglify-js` (`3.19.3`)
+   - Vulnerability ID: CVE-2015-8857
+   - Severity: CRITICAL
+   - Description: Incorrect Handling of Non-Boolean Comparisons During Minification in uglify-js
+   - Published Date: 2017-10-24 18:33:36+00:00
+   - Version Range: < 2.4.24
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8857
+### High Vulnerabilities (Action Recommended)
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2017-18077
+   - Severity: HIGH
+   - Description: ReDoS in brace-expansion
+   - Published Date: 2018-01-29 15:50:46+00:00
+   - Version Range: < 1.1.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-18077
+ - `glob-parent` (`6.0.2`)
+   - Vulnerability ID: CVE-2020-28469
+   - Severity: HIGH
+   - Description: glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex
+   - Published Date: 2021-06-07 21:56:34+00:00
+   - Version Range: >= 4.0.0, < 5.1.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28469
+ - `glob-parent` (`6.0.2`)
+   - Vulnerability ID: CVE-2021-35065
+   - Severity: HIGH
+   - Description: glob-parent 6.0.0 vulnerable to Regular Expression Denial of Service
+   - Published Date: 2022-07-18 17:03:23+00:00
+   - Version Range: = 6.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-35065
+ - `minimatch` (`3.1.2`)
+   - Vulnerability ID: CVE-2022-3517
+   - Severity: HIGH
+   - Description: minimatch ReDoS vulnerability
+   - Published Date: 2022-10-18 12:00:32+00:00
+   - Version Range: < 3.0.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-3517
+ - `minimatch` (`3.1.2`)
+   - Vulnerability ID: CVE-2016-10540
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in minimatch
+   - Published Date: 2018-10-09 00:40:41+00:00
+   - Version Range: < 3.0.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10540
+ - `fast-json-patch` (`3.1.1`)
+   - Vulnerability ID: CVE-2021-4279
+   - Severity: HIGH
+   - Description: Starcounter-Jack JSON-Patch Prototype Pollution vulnerability
+   - Published Date: 2022-12-25 21:30:22+00:00
+   - Version Range: < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-4279
+ - `follow-redirects` (`1.15.9`)
+   - Vulnerability ID: CVE-2022-0155
+   - Severity: HIGH
+   - Description: Exposure of sensitive information in follow-redirects
+   - Published Date: 2022-01-12 22:46:26+00:00
+   - Version Range: < 1.14.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-0155
+ - `@apidevtools/json-schema-ref-parser` (`11.6.4`)
+   - Vulnerability ID: CVE-2024-29651
+   - Severity: HIGH
+   - Description: json-schema-ref-parser Prototype Pollution issue
+   - Published Date: 2024-05-20 18:31:23+00:00
+   - Version Range: >= 11.0.0, <= 11.1.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-29651
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: >= 7.0.0, < 7.5.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: < 5.7.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: >= 6.0.0, < 6.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2015-8855
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in semver
+   - Published Date: 2017-10-24 18:33:36+00:00
+   - Version Range: < 4.3.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8855
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: >= 7.0.0, < 7.5.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: < 5.7.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: >= 6.0.0, < 6.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2015-8855
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in semver
+   - Published Date: 2017-10-24 18:33:36+00:00
+   - Version Range: < 4.3.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8855
+ - `yaml` (`1.10.2`)
+   - Vulnerability ID: CVE-2023-2251
+   - Severity: HIGH
+   - Description: Uncaught Exception in yaml
+   - Published Date: 2023-04-24 15:30:34+00:00
+   - Version Range: >= 2.0.0-5, < 2.2.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-2251
+ - `cross-spawn` (`7.0.6`)
+   - Vulnerability ID: CVE-2024-21538
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service (ReDoS) in cross-spawn
+   - Published Date: 2024-11-08 06:30:47+00:00
+   - Version Range: < 6.0.6
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21538
+ - `cross-spawn` (`7.0.6`)
+   - Vulnerability ID: CVE-2024-21538
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service (ReDoS) in cross-spawn
+   - Published Date: 2024-11-08 06:30:47+00:00
+   - Version Range: >= 7.0.0, < 7.0.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21538
+ - `debug` (`4.3.4`)
+   - Vulnerability ID: CVE-2017-20165
+   - Severity: HIGH
+   - Description: debug Inefficient Regular Expression Complexity vulnerability
+   - Published Date: 2023-01-09 12:30:19+00:00
+   - Version Range: >= 3.0.0, < 3.1.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-20165
+ - `debug` (`4.3.4`)
+   - Vulnerability ID: CVE-2017-20165
+   - Severity: HIGH
+   - Description: debug Inefficient Regular Expression Complexity vulnerability
+   - Published Date: 2023-01-09 12:30:19+00:00
+   - Version Range: < 2.6.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-20165
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2017-18077
+   - Severity: HIGH
+   - Description: ReDoS in brace-expansion
+   - Published Date: 2018-01-29 15:50:46+00:00
+   - Version Range: < 1.1.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-18077
+ - `minimatch` (`3.1.2`)
+   - Vulnerability ID: CVE-2022-3517
+   - Severity: HIGH
+   - Description: minimatch ReDoS vulnerability
+   - Published Date: 2022-10-18 12:00:32+00:00
+   - Version Range: < 3.0.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-3517
+ - `minimatch` (`3.1.2`)
+   - Vulnerability ID: CVE-2016-10540
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in minimatch
+   - Published Date: 2018-10-09 00:40:41+00:00
+   - Version Range: < 3.0.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10540
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2017-18077
+   - Severity: HIGH
+   - Description: ReDoS in brace-expansion
+   - Published Date: 2018-01-29 15:50:46+00:00
+   - Version Range: < 1.1.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-18077
+ - `minimatch` (`3.1.2`)
+   - Vulnerability ID: CVE-2022-3517
+   - Severity: HIGH
+   - Description: minimatch ReDoS vulnerability
+   - Published Date: 2022-10-18 12:00:32+00:00
+   - Version Range: < 3.0.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-3517
+ - `minimatch` (`3.1.2`)
+   - Vulnerability ID: CVE-2016-10540
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in minimatch
+   - Published Date: 2018-10-09 00:40:41+00:00
+   - Version Range: < 3.0.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10540
+ - `glob-parent` (`5.1.2`)
+   - Vulnerability ID: CVE-2020-28469
+   - Severity: HIGH
+   - Description: glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex
+   - Published Date: 2021-06-07 21:56:34+00:00
+   - Version Range: >= 4.0.0, < 5.1.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28469
+ - `glob-parent` (`5.1.2`)
+   - Vulnerability ID: CVE-2021-35065
+   - Severity: HIGH
+   - Description: glob-parent 6.0.0 vulnerable to Regular Expression Denial of Service
+   - Published Date: 2022-07-18 17:03:23+00:00
+   - Version Range: = 6.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-35065
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2017-18077
+   - Severity: HIGH
+   - Description: ReDoS in brace-expansion
+   - Published Date: 2018-01-29 15:50:46+00:00
+   - Version Range: < 1.1.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-18077
+ - `minimatch` (`3.1.2`)
+   - Vulnerability ID: CVE-2022-3517
+   - Severity: HIGH
+   - Description: minimatch ReDoS vulnerability
+   - Published Date: 2022-10-18 12:00:32+00:00
+   - Version Range: < 3.0.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-3517
+ - `minimatch` (`3.1.2`)
+   - Vulnerability ID: CVE-2016-10540
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in minimatch
+   - Published Date: 2018-10-09 00:40:41+00:00
+   - Version Range: < 3.0.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10540
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: GHSA-2cf5-4w76-r9qv
+   - Severity: HIGH
+   - Description: Arbitrary Code Execution in handlebars
+   - Published Date: 2020-09-04 14:57:38+00:00
+   - Version Range: >= 4.0.0, < 4.5.2
+   - Reference URL: https://www.npmjs.com/advisories/1316
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: GHSA-2cf5-4w76-r9qv
+   - Severity: HIGH
+   - Description: Arbitrary Code Execution in handlebars
+   - Published Date: 2020-09-04 14:57:38+00:00
+   - Version Range: < 3.0.8
+   - Reference URL: https://www.npmjs.com/advisories/1316
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: CVE-2019-20920
+   - Severity: HIGH
+   - Description: Arbitrary Code Execution in Handlebars
+   - Published Date: 2022-02-10 20:38:19+00:00
+   - Version Range: >= 4.0.0, < 4.5.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-20920
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: CVE-2019-20920
+   - Severity: HIGH
+   - Description: Arbitrary Code Execution in Handlebars
+   - Published Date: 2022-02-10 20:38:19+00:00
+   - Version Range: < 3.0.8
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-20920
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: GHSA-q42p-pg8m-cqh6
+   - Severity: HIGH
+   - Description: Prototype Pollution in handlebars
+   - Published Date: 2019-06-05 14:07:48+00:00
+   - Version Range: < 3.0.7
+   - Reference URL: https://github.com/handlebars-lang/handlebars.js/issues/1495
+ - `handlebars` (`4.7.8`)
+   - Vulnerability ID: GHSA-q42p-pg8m-cqh6
+   - Severity: HIGH
+   - Description: Prototype Pollution in handlebars
+   - Published Date: 2019-06-05 14:07:48+00:00
+   - Version Range: >= 4.0.0, < 4.0.14
+   - Reference URL: https://github.com/handlebars-lang/handlebars.js/issues/1495
+ - `https-proxy-agent` (`7.0.6`)
+   - Vulnerability ID: GHSA-qrg3-f6h6-vq8q
+   - Severity: HIGH
+   - Description: Denial of Service in https-proxy-agent
+   - Published Date: 2020-08-19 22:15:57+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://hackerone.com/reports/319532
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 3.0.0, < 3.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 4.0.0, < 4.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 5.0.0, < 5.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 6.0.0, < 6.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `https-proxy-agent` (`5.0.1`)
+   - Vulnerability ID: GHSA-qrg3-f6h6-vq8q
+   - Severity: HIGH
+   - Description: Denial of Service in https-proxy-agent
+   - Published Date: 2020-08-19 22:15:57+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://hackerone.com/reports/319532
+ - `minimatch` (`5.1.6`)
+   - Vulnerability ID: CVE-2022-3517
+   - Severity: HIGH
+   - Description: minimatch ReDoS vulnerability
+   - Published Date: 2022-10-18 12:00:32+00:00
+   - Version Range: < 3.0.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-3517
+ - `minimatch` (`5.1.6`)
+   - Vulnerability ID: CVE-2016-10540
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in minimatch
+   - Published Date: 2018-10-09 00:40:41+00:00
+   - Version Range: < 3.0.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10540
+ - `ms` (`2.1.2`)
+   - Vulnerability ID: CVE-2015-8315
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in ms
+   - Published Date: 2017-10-24 18:33:36+00:00
+   - Version Range: < 0.7.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8315
+ - `node-fetch` (`2.7.0`)
+   - Vulnerability ID: CVE-2022-0235
+   - Severity: HIGH
+   - Description: node-fetch forwards secure headers to untrusted sites
+   - Published Date: 2022-01-21 23:55:52+00:00
+   - Version Range: < 2.6.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-0235
+ - `node-fetch` (`2.7.0`)
+   - Vulnerability ID: CVE-2022-0235
+   - Severity: HIGH
+   - Description: node-fetch forwards secure headers to untrusted sites
+   - Published Date: 2022-01-21 23:55:52+00:00
+   - Version Range: >= 3.0.0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-0235
+ - `pdfjs-dist` (`4.6.82`)
+   - Vulnerability ID: CVE-2018-5158
+   - Severity: HIGH
+   - Description: Malicious PDF can inject JavaScript into PDF Viewer
+   - Published Date: 2022-05-14 01:22:02+00:00
+   - Version Range: < 1.10.100
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-5158
+ - `pdfjs-dist` (`4.6.82`)
+   - Vulnerability ID: CVE-2018-5158
+   - Severity: HIGH
+   - Description: Malicious PDF can inject JavaScript into PDF Viewer
+   - Published Date: 2022-05-14 01:22:02+00:00
+   - Version Range: >= 2.0.0, < 2.0.550
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-5158
+ - `pdfjs-dist` (`4.6.82`)
+   - Vulnerability ID: CVE-2024-4367
+   - Severity: HIGH
+   - Description: PDF.js vulnerable to arbitrary JavaScript execution upon opening a malicious PDF
+   - Published Date: 2024-05-07 10:25:08+00:00
+   - Version Range: <= 4.1.392
+   - Reference URL: https://github.com/mozilla/pdf.js/security/advisories/GHSA-wgrm-67xf-hhpq
+ - `js-yaml` (`4.1.0`)
+   - Vulnerability ID: GHSA-8j8c-7jfh-h6hx
+   - Severity: HIGH
+   - Description: Code Injection in js-yaml
+   - Published Date: 2019-06-04 20:14:07+00:00
+   - Version Range: < 3.13.1
+   - Reference URL: https://github.com/nodeca/js-yaml/pull/480
+ - `json5` (`2.2.3`)
+   - Vulnerability ID: CVE-2022-46175
+   - Severity: HIGH
+   - Description: Prototype Pollution in JSON5 via Parse Method
+   - Published Date: 2022-12-29 01:51:03+00:00
+   - Version Range: < 1.0.2
+   - Reference URL: https://github.com/json5/json5/security/advisories/GHSA-9c47-m6qq-7p4h
+ - `json5` (`2.2.3`)
+   - Vulnerability ID: CVE-2022-46175
+   - Severity: HIGH
+   - Description: Prototype Pollution in JSON5 via Parse Method
+   - Published Date: 2022-12-29 01:51:03+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/json5/json5/security/advisories/GHSA-9c47-m6qq-7p4h
+ - `lilconfig` (`2.1.0`)
+   - Vulnerability ID: CVE-2024-21537
+   - Severity: HIGH
+   - Description: lilconfig Code Injection vulnerability
+   - Published Date: 2024-10-31 06:30:45+00:00
+   - Version Range: >= 3.1.0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21537
+ - `lodash.merge` (`4.6.2`)
+   - Vulnerability ID: GHSA-2m96-9w4j-wgv7
+   - Severity: HIGH
+   - Description: Prototype Pollution in lodash.merge
+   - Published Date: 2020-09-03 18:06:00+00:00
+   - Version Range: < 4.6.1
+   - Reference URL: https://www.npmjs.com/advisories/1067
+ - `lodash.merge` (`4.6.2`)
+   - Vulnerability ID: GHSA-h726-x36v-rx45
+   - Severity: HIGH
+   - Description: Prototype Pollution in lodash.merge
+   - Published Date: 2020-09-03 18:04:54+00:00
+   - Version Range: < 4.6.2
+   - Reference URL: https://www.npmjs.com/advisories/1066
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: >= 7.0.0, < 7.5.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: < 5.7.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: >= 6.0.0, < 6.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`6.3.1`)
+   - Vulnerability ID: CVE-2015-8855
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in semver
+   - Published Date: 2017-10-24 18:33:36+00:00
+   - Version Range: < 4.3.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8855
+ - `minimatch` (`9.0.5`)
+   - Vulnerability ID: CVE-2022-3517
+   - Severity: HIGH
+   - Description: minimatch ReDoS vulnerability
+   - Published Date: 2022-10-18 12:00:32+00:00
+   - Version Range: < 3.0.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-3517
+ - `minimatch` (`9.0.5`)
+   - Vulnerability ID: CVE-2016-10540
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in minimatch
+   - Published Date: 2018-10-09 00:40:41+00:00
+   - Version Range: < 3.0.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10540
+ - `acorn` (`8.14.0`)
+   - Vulnerability ID: GHSA-6chw-6frg-f759
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in Acorn
+   - Published Date: 2020-04-03 21:48:38+00:00
+   - Version Range: >= 5.5.0, < 5.7.4
+   - Reference URL: https://github.com/acornjs/acorn/issues/929
+ - `acorn` (`8.14.0`)
+   - Vulnerability ID: GHSA-6chw-6frg-f759
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in Acorn
+   - Published Date: 2020-04-03 21:48:38+00:00
+   - Version Range: >= 7.0.0, < 7.1.1
+   - Reference URL: https://github.com/acornjs/acorn/issues/929
+ - `acorn` (`8.14.0`)
+   - Vulnerability ID: GHSA-6chw-6frg-f759
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in Acorn
+   - Published Date: 2020-04-03 21:48:38+00:00
+   - Version Range: >= 6.0.0, < 6.4.1
+   - Reference URL: https://github.com/acornjs/acorn/issues/929
+ - `ansi-regex` (`5.0.1`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 3.0.0, < 3.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`5.0.1`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 4.0.0, < 4.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`5.0.1`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 5.0.0, < 5.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`5.0.1`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 6.0.0, < 6.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `axios` (`1.7.5`)
+   - Vulnerability ID: CVE-2025-27152
+   - Severity: HIGH
+   - Description: axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL
+   - Published Date: 2025-03-07 15:16:00+00:00
+   - Version Range: < 0.30.0
+   - Reference URL: https://github.com/axios/axios/security/advisories/GHSA-jr5f-v2jv-69x6
+ - `axios` (`1.7.5`)
+   - Vulnerability ID: CVE-2025-27152
+   - Severity: HIGH
+   - Description: axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL
+   - Published Date: 2025-03-07 15:16:00+00:00
+   - Version Range: >= 1.0.0, < 1.8.2
+   - Reference URL: https://github.com/axios/axios/security/advisories/GHSA-jr5f-v2jv-69x6
+ - `axios` (`1.7.5`)
+   - Vulnerability ID: CVE-2021-3749
+   - Severity: HIGH
+   - Description: axios Inefficient Regular Expression Complexity vulnerability
+   - Published Date: 2021-09-01 18:23:02+00:00
+   - Version Range: < 0.21.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3749
+ - `axios` (`1.7.5`)
+   - Vulnerability ID: CVE-2024-39338
+   - Severity: HIGH
+   - Description: Server-Side Request Forgery in axios
+   - Published Date: 2024-08-12 15:30:49+00:00
+   - Version Range: >= 1.3.2, <= 1.7.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-39338
+ - `axios` (`1.7.5`)
+   - Vulnerability ID: CVE-2019-10742
+   - Severity: HIGH
+   - Description: Denial of Service in axios
+   - Published Date: 2019-05-29 18:04:45+00:00
+   - Version Range: <= 0.18.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-10742
+ - `brace-expansion` (`2.0.1`)
+   - Vulnerability ID: CVE-2017-18077
+   - Severity: HIGH
+   - Description: ReDoS in brace-expansion
+   - Published Date: 2018-01-29 15:50:46+00:00
+   - Version Range: < 1.1.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-18077
+ - `braces` (`3.0.3`)
+   - Vulnerability ID: CVE-2024-4068
+   - Severity: HIGH
+   - Description: Uncontrolled resource consumption in braces
+   - Published Date: 2024-05-14 18:30:54+00:00
+   - Version Range: < 3.0.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-4068
+ - `canvas` (`2.11.2`)
+   - Vulnerability ID: CVE-2020-8215
+   - Severity: HIGH
+   - Description: Buffer overflow  in canvas
+   - Published Date: 2021-05-07 16:05:16+00:00
+   - Version Range: < 1.6.11
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-8215
+ - `semver` (`7.6.0`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: >= 7.0.0, < 7.5.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`7.6.0`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: < 5.7.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`7.6.0`)
+   - Vulnerability ID: CVE-2022-25883
+   - Severity: HIGH
+   - Description: semver vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-21 06:30:28+00:00
+   - Version Range: >= 6.0.0, < 6.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-25883
+ - `semver` (`7.6.0`)
+   - Vulnerability ID: CVE-2015-8855
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in semver
+   - Published Date: 2017-10-24 18:33:36+00:00
+   - Version Range: < 4.3.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8855
+ - `simple-get` (`3.1.1`)
+   - Vulnerability ID: CVE-2022-0355
+   - Severity: HIGH
+   - Description: Exposure of Sensitive Information in simple-get
+   - Published Date: 2022-01-28 22:54:16+00:00
+   - Version Range: < 2.8.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-0355
+ - `simple-get` (`3.1.1`)
+   - Vulnerability ID: CVE-2022-0355
+   - Severity: HIGH
+   - Description: Exposure of Sensitive Information in simple-get
+   - Published Date: 2022-01-28 22:54:16+00:00
+   - Version Range: >= 3.0.0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-0355
+ - `simple-get` (`3.1.1`)
+   - Vulnerability ID: CVE-2022-0355
+   - Severity: HIGH
+   - Description: Exposure of Sensitive Information in simple-get
+   - Published Date: 2022-01-28 22:54:16+00:00
+   - Version Range: = 4.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-0355
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 3.0.0, < 3.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 4.0.0, < 4.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 5.0.0, < 5.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 6.0.0, < 6.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `glob-parent` (`6.0.2`)
+   - Vulnerability ID: CVE-2020-28469
+   - Severity: HIGH
+   - Description: glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex
+   - Published Date: 2021-06-07 21:56:34+00:00
+   - Version Range: >= 4.0.0, < 5.1.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28469
+ - `glob-parent` (`6.0.2`)
+   - Vulnerability ID: CVE-2021-35065
+   - Severity: HIGH
+   - Description: glob-parent 6.0.0 vulnerable to Regular Expression Denial of Service
+   - Published Date: 2022-07-18 17:03:23+00:00
+   - Version Range: = 6.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-35065
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-37712
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links
+   - Published Date: 2021-08-31 16:05:17+00:00
+   - Version Range: >= 3.0.0, < 4.4.18
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-qq89-hq3f-393p
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-37701
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links
+   - Published Date: 2021-08-31 16:05:27+00:00
+   - Version Range: >= 3.0.0, < 4.4.16
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-9r2w-394v-53qc
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-32803
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning
+   - Published Date: 2021-08-03 19:00:40+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-32803
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning
+   - Published Date: 2021-08-03 19:00:40+00:00
+   - Version Range: >= 6.0.0, < 6.1.2
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-32803
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning
+   - Published Date: 2021-08-03 19:00:40+00:00
+   - Version Range: >= 5.0.0, < 5.0.7
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-32803
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning
+   - Published Date: 2021-08-03 19:00:40+00:00
+   - Version Range: >= 4.0.0, < 4.4.15
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-37701
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links
+   - Published Date: 2021-08-31 16:05:27+00:00
+   - Version Range: >= 6.0.0, < 6.1.7
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-9r2w-394v-53qc
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-37701
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links
+   - Published Date: 2021-08-31 16:05:27+00:00
+   - Version Range: >= 5.0.0, < 5.0.8
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-9r2w-394v-53qc
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2021-37712
+   - Severity: HIGH
+   - Description: Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links
+   - Published Date: 2021-08-31 16:05:17+00:00
+   - Version Range: >= 6.0.0, < 6.1.9
+   - Reference URL: https://github.com/npm/node-tar/security/advisories/GHSA-qq89-hq3f-393p
+ - `ua-parser-js` (`1.0.40`)
+   - Vulnerability ID: CVE-2022-25927
+   - Severity: HIGH
+   - Description: ReDoS Vulnerability in ua-parser-js version
+   - Published Date: 2023-01-24 15:36:32+00:00
+   - Version Range: >= 0.8.0, < 1.0.33
+   - Reference URL: https://github.com/faisalman/ua-parser-js/security/advisories/GHSA-fhg7-m89q-25r3
+ - `ua-parser-js` (`1.0.40`)
+   - Vulnerability ID: CVE-2022-25927
+   - Severity: HIGH
+   - Description: ReDoS Vulnerability in ua-parser-js version
+   - Published Date: 2023-01-24 15:36:32+00:00
+   - Version Range: < 0.7.33
+   - Reference URL: https://github.com/faisalman/ua-parser-js/security/advisories/GHSA-fhg7-m89q-25r3
+ - `ua-parser-js` (`1.0.40`)
+   - Vulnerability ID: GHSA-pjwm-rvh2-c87w
+   - Severity: HIGH
+   - Description: Embedded malware in ua-parser-js
+   - Published Date: 2021-10-22 20:38:14+00:00
+   - Version Range: = 1.0.0
+   - Reference URL: https://github.com/faisalman/ua-parser-js/issues/536
+ - `ua-parser-js` (`1.0.40`)
+   - Vulnerability ID: GHSA-pjwm-rvh2-c87w
+   - Severity: HIGH
+   - Description: Embedded malware in ua-parser-js
+   - Published Date: 2021-10-22 20:38:14+00:00
+   - Version Range: = 0.8.0
+   - Reference URL: https://github.com/faisalman/ua-parser-js/issues/536
+ - `ua-parser-js` (`1.0.40`)
+   - Vulnerability ID: GHSA-pjwm-rvh2-c87w
+   - Severity: HIGH
+   - Description: Embedded malware in ua-parser-js
+   - Published Date: 2021-10-22 20:38:14+00:00
+   - Version Range: = 0.7.29
+   - Reference URL: https://github.com/faisalman/ua-parser-js/issues/536
+ - `ua-parser-js` (`1.0.40`)
+   - Vulnerability ID: CVE-2020-7733
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in ua-parser-js
+   - Published Date: 2021-05-07 16:18:19+00:00
+   - Version Range: < 0.7.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-7733
+ - `ua-parser-js` (`1.0.40`)
+   - Vulnerability ID: CVE-2020-7793
+   - Severity: HIGH
+   - Description: ua-parser-js Regular Expression Denial of Service vulnerability
+   - Published Date: 2022-02-09 22:46:53+00:00
+   - Version Range: < 0.7.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-7793
+ - `ua-parser-js` (`1.0.40`)
+   - Vulnerability ID: CVE-2021-27292
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service (ReDoS) in ua-parser-js
+   - Published Date: 2021-05-06 16:11:13+00:00
+   - Version Range: >= 0.7.14, < 0.7.24
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27292
+ - `uglify-js` (`3.19.3`)
+   - Vulnerability ID: GHSA-g6f4-j6c2-w3p3
+   - Severity: HIGH
+   - Description: High severity vulnerability that affects uglify-js
+   - Published Date: 2018-10-09 00:39:43+00:00
+   - Version Range: < 2.4.24
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8857
+ - `uglify-js` (`3.19.3`)
+   - Vulnerability ID: CVE-2015-8858
+   - Severity: HIGH
+   - Description: Regular Expression Denial of Service in uglify-js
+   - Published Date: 2017-10-24 18:33:36+00:00
+   - Version Range: < 2.6.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8858
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 3.0.0, < 3.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 4.0.0, < 4.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 5.0.0, < 5.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `ansi-regex` (`6.1.0`)
+   - Vulnerability ID: CVE-2021-3807
+   - Severity: HIGH
+   - Description: Inefficient Regular Expression Complexity in chalk/ansi-regex
+   - Published Date: 2021-09-20 20:20:09+00:00
+   - Version Range: >= 6.0.0, < 6.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-3807
+ - `xlsx` (`0.18.5`)
+   - Vulnerability ID: CVE-2024-22363
+   - Severity: HIGH
+   - Description: SheetJS Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2024-04-05 06:30:46+00:00
+   - Version Range: < 0.20.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-22363
+ - `xlsx` (`0.18.5`)
+   - Vulnerability ID: CVE-2023-30533
+   - Severity: HIGH
+   - Description: Prototype Pollution in sheetJS
+   - Published Date: 2023-04-24 09:30:19+00:00
+   - Version Range: < 0.19.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-30533
+ - `yaml` (`2.7.0`)
+   - Vulnerability ID: CVE-2023-2251
+   - Severity: HIGH
+   - Description: Uncaught Exception in yaml
+   - Published Date: 2023-04-24 15:30:34+00:00
+   - Version Range: >= 2.0.0-5, < 2.2.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-2251
+ - `lilconfig` (`3.1.3`)
+   - Vulnerability ID: CVE-2024-21537
+   - Severity: HIGH
+   - Description: lilconfig Code Injection vulnerability
+   - Published Date: 2024-10-31 06:30:45+00:00
+   - Version Range: >= 3.1.0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-21537
+ - `react` (`18.3.1`)
+   - Vulnerability ID: GHSA-hg79-j56m-fxgv
+   - Severity: HIGH
+   - Description: Cross-Site Scripting in react
+   - Published Date: 2020-09-04 15:26:04+00:00
+   - Version Range: >= 0.0.1, < 0.14.0
+   - Reference URL: https://snyk.io/vuln/npm:react:20150318
+ - `react-router` (`6.22.3`)
+   - Vulnerability ID: CVE-2025-43865
+   - Severity: HIGH
+   - Description: React Router allows pre-render data spoofing on React-Router framework mode
+   - Published Date: 2025-04-24 16:31:32+00:00
+   - Version Range: >= 7.0, <= 7.5.1
+   - Reference URL: https://github.com/remix-run/react-router/security/advisories/GHSA-cpj6-fhp6-mr6j
+ - `react-router` (`6.22.3`)
+   - Vulnerability ID: CVE-2025-43864
+   - Severity: HIGH
+   - Description: React Router allows a DoS via cache poisoning by forcing SPA mode
+   - Published Date: 2025-04-24 16:31:16+00:00
+   - Version Range: >= 7.2.0, <= 7.5.1
+   - Reference URL: https://github.com/remix-run/react-router/security/advisories/GHSA-f46r-rw29-r322
+ - `rollup` (`4.30.1`)
+   - Vulnerability ID: CVE-2024-47068
+   - Severity: HIGH
+   - Description: DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS
+   - Published Date: 2024-09-23 22:11:02+00:00
+   - Version Range: < 2.79.2
+   - Reference URL: https://github.com/rollup/rollup/security/advisories/GHSA-gcx4-mw62-g8wm
+ - `rollup` (`4.30.1`)
+   - Vulnerability ID: CVE-2024-47068
+   - Severity: HIGH
+   - Description: DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS
+   - Published Date: 2024-09-23 22:11:02+00:00
+   - Version Range: >= 3.0.0, < 3.29.5
+   - Reference URL: https://github.com/rollup/rollup/security/advisories/GHSA-gcx4-mw62-g8wm
+ - `rollup` (`4.30.1`)
+   - Vulnerability ID: CVE-2024-47068
+   - Severity: HIGH
+   - Description: DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS
+   - Published Date: 2024-09-23 22:11:02+00:00
+   - Version Range: >= 4.0.0, < 4.22.4
+   - Reference URL: https://github.com/rollup/rollup/security/advisories/GHSA-gcx4-mw62-g8wm
+### Moderate Vulnerabilities (Review Recommended)
+ - `follow-redirects` (`1.15.9`)
+   - Vulnerability ID: CVE-2024-28849
+   - Severity: MODERATE
+   - Description: follow-redirects' Proxy-Authorization header kept across hosts
+   - Published Date: 2024-03-14 17:19:42+00:00
+   - Version Range: <= 1.15.5
+   - Reference URL: https://github.com/follow-redirects/follow-redirects/security/advisories/GHSA-cxjh-pqwp-8mfp
+ - `follow-redirects` (`1.15.9`)
+   - Vulnerability ID: CVE-2023-26159
+   - Severity: MODERATE
+   - Description: Follow Redirects improperly handles URLs in the url.parse() function
+   - Published Date: 2024-01-02 06:30:30+00:00
+   - Version Range: < 1.15.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26159
+ - `follow-redirects` (`1.15.9`)
+   - Vulnerability ID: CVE-2022-0536
+   - Severity: MODERATE
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in follow-redirects
+   - Published Date: 2022-02-10 00:00:31+00:00
+   - Version Range: < 1.14.8
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-0536
+ - `@babel/helpers` (`7.26.0`)
+   - Vulnerability ID: CVE-2025-27789
+   - Severity: MODERATE
+   - Description: Babel has inefficient RegExp complexity in generated code with .replace when transpiling named capturing groups
+   - Published Date: 2025-03-11 20:30:18+00:00
+   - Version Range: >= 8.0.0-alpha.0, < 8.0.0-alpha.16
+   - Reference URL: https://github.com/babel/babel/security/advisories/GHSA-968p-4wvh-cqc8
+ - `@babel/helpers` (`7.26.0`)
+   - Vulnerability ID: CVE-2025-27789
+   - Severity: MODERATE
+   - Description: Babel has inefficient RegExp complexity in generated code with .replace when transpiling named capturing groups
+   - Published Date: 2025-03-11 20:30:18+00:00
+   - Version Range: < 7.26.10
+   - Reference URL: https://github.com/babel/babel/security/advisories/GHSA-968p-4wvh-cqc8
+ - `@babel/runtime` (`7.26.0`)
+   - Vulnerability ID: CVE-2025-27789
+   - Severity: MODERATE
+   - Description: Babel has inefficient RegExp complexity in generated code with .replace when transpiling named capturing groups
+   - Published Date: 2025-03-11 20:30:18+00:00
+   - Version Range: >= 8.0.0-alpha.0, < 8.0.0-alpha.16
+   - Reference URL: https://github.com/babel/babel/security/advisories/GHSA-968p-4wvh-cqc8
+ - `@babel/runtime` (`7.26.0`)
+   - Vulnerability ID: CVE-2025-27789
+   - Severity: MODERATE
+   - Description: Babel has inefficient RegExp complexity in generated code with .replace when transpiling named capturing groups
+   - Published Date: 2025-03-11 20:30:18+00:00
+   - Version Range: < 7.26.10
+   - Reference URL: https://github.com/babel/babel/security/advisories/GHSA-968p-4wvh-cqc8
+ - `esbuild` (`0.20.2`)
+   - Vulnerability ID: GHSA-67mh-4wv8-2f99
+   - Severity: MODERATE
+   - Description: esbuild enables any website to send any requests to the development server and read the response
+   - Published Date: 2025-02-10 17:48:07+00:00
+   - Version Range: <= 0.24.2
+   - Reference URL: https://github.com/evanw/esbuild/security/advisories/GHSA-67mh-4wv8-2f99
+ - `eslint` (`8.57.0`)
+   - Vulnerability ID: GHSA-jcgq-xh2f-2hfm
+   - Severity: MODERATE
+   - Description: Regular Expression Denial of Service
+   - Published Date: 2021-02-25 01:20:42+00:00
+   - Version Range: < 4.18.2
+   - Reference URL: https://github.com/eslint/eslint/issues/10002
+ - `https-proxy-agent` (`7.0.6`)
+   - Vulnerability ID: GHSA-pc5p-h8pf-mvwp
+   - Severity: MODERATE
+   - Description: Machine-In-The-Middle in https-proxy-agent
+   - Published Date: 2020-04-16 03:14:56+00:00
+   - Version Range: < 2.2.3
+   - Reference URL: https://github.com/TooTallNate/node-https-proxy-agent/commit/36d8cf509f877fa44f4404fce57ebaf9410fe51b
+ - `https-proxy-agent` (`5.0.1`)
+   - Vulnerability ID: GHSA-pc5p-h8pf-mvwp
+   - Severity: MODERATE
+   - Description: Machine-In-The-Middle in https-proxy-agent
+   - Published Date: 2020-04-16 03:14:56+00:00
+   - Version Range: < 2.2.3
+   - Reference URL: https://github.com/TooTallNate/node-https-proxy-agent/commit/36d8cf509f877fa44f4404fce57ebaf9410fe51b
+ - `ms` (`2.1.2`)
+   - Vulnerability ID: CVE-2017-20162
+   - Severity: MODERATE
+   - Description: Vercel ms Inefficient Regular Expression Complexity vulnerability
+   - Published Date: 2023-01-05 12:30:27+00:00
+   - Version Range: < 2.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-20162
+ - `nanoid` (`3.3.8`)
+   - Vulnerability ID: CVE-2024-55565
+   - Severity: MODERATE
+   - Description: Predictable results in nanoid generation when given non-integer values
+   - Published Date: 2024-12-09 03:30:59+00:00
+   - Version Range: < 3.3.8
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-55565
+ - `nanoid` (`3.3.8`)
+   - Vulnerability ID: CVE-2024-55565
+   - Severity: MODERATE
+   - Description: Predictable results in nanoid generation when given non-integer values
+   - Published Date: 2024-12-09 03:30:59+00:00
+   - Version Range: >= 4.0.0, < 5.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-55565
+ - `nanoid` (`3.3.8`)
+   - Vulnerability ID: CVE-2021-23566
+   - Severity: MODERATE
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in nanoid
+   - Published Date: 2022-01-21 23:57:06+00:00
+   - Version Range: >= 3.0.0, < 3.1.31
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23566
+ - `node-fetch` (`2.7.0`)
+   - Vulnerability ID: CVE-2022-2596
+   - Severity: MODERATE
+   - Description: node-fetch Inefficient Regular Expression Complexity 
+   - Published Date: 2022-08-02 00:00:25+00:00
+   - Version Range: >= 3.0.0, < 3.2.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-2596
+ - `path-parse` (`1.0.7`)
+   - Vulnerability ID: CVE-2021-23343
+   - Severity: MODERATE
+   - Description: Regular Expression Denial of Service in path-parse
+   - Published Date: 2021-08-10 15:33:47+00:00
+   - Version Range: < 1.0.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23343
+ - `js-yaml` (`4.1.0`)
+   - Vulnerability ID: GHSA-2pr6-76vf-7546
+   - Severity: MODERATE
+   - Description: Denial of Service in js-yaml
+   - Published Date: 2019-06-05 14:35:29+00:00
+   - Version Range: < 3.13.0
+   - Reference URL: https://github.com/nodeca/js-yaml/issues/475
+ - `micromatch` (`4.0.8`)
+   - Vulnerability ID: CVE-2024-4067
+   - Severity: MODERATE
+   - Description: Regular Expression Denial of Service (ReDoS) in micromatch
+   - Published Date: 2024-05-14 18:30:54+00:00
+   - Version Range: < 4.0.8
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-4067
+ - `minimist` (`1.2.8`)
+   - Vulnerability ID: CVE-2020-7598
+   - Severity: MODERATE
+   - Description: Prototype Pollution in minimist
+   - Published Date: 2020-04-03 21:48:32+00:00
+   - Version Range: >= 1.0.0, < 1.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-7598
+ - `minimist` (`1.2.8`)
+   - Vulnerability ID: CVE-2020-7598
+   - Severity: MODERATE
+   - Description: Prototype Pollution in minimist
+   - Published Date: 2020-04-03 21:48:32+00:00
+   - Version Range: < 0.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-7598
+ - `minimist` (`1.2.8`)
+   - Vulnerability ID: GHSA-7fhm-mqm4-2wp7
+   - Severity: MODERATE
+   - Description: Withdrawn: ESLint dependencies are vulnerable (ReDoS and Prototype Pollution)
+   - Published Date: 2020-03-13 20:36:16+00:00
+   - Version Range: < 1.2.2
+   - Reference URL: https://github.com/advisories/GHSA-6chw-6frg-f759
+ - `acorn` (`8.14.0`)
+   - Vulnerability ID: GHSA-7fhm-mqm4-2wp7
+   - Severity: MODERATE
+   - Description: Withdrawn: ESLint dependencies are vulnerable (ReDoS and Prototype Pollution)
+   - Published Date: 2020-03-13 20:36:16+00:00
+   - Version Range: >= 7.0.0, < 7.1.1
+   - Reference URL: https://github.com/advisories/GHSA-6chw-6frg-f759
+ - `acorn` (`8.14.0`)
+   - Vulnerability ID: GHSA-7fhm-mqm4-2wp7
+   - Severity: MODERATE
+   - Description: Withdrawn: ESLint dependencies are vulnerable (ReDoS and Prototype Pollution)
+   - Published Date: 2020-03-13 20:36:16+00:00
+   - Version Range: >= 6.0.0, < 6.4.1
+   - Reference URL: https://github.com/advisories/GHSA-6chw-6frg-f759
+ - `acorn` (`8.14.0`)
+   - Vulnerability ID: GHSA-7fhm-mqm4-2wp7
+   - Severity: MODERATE
+   - Description: Withdrawn: ESLint dependencies are vulnerable (ReDoS and Prototype Pollution)
+   - Published Date: 2020-03-13 20:36:16+00:00
+   - Version Range: < 5.7.4
+   - Reference URL: https://github.com/advisories/GHSA-6chw-6frg-f759
+ - `ajv` (`6.12.6`)
+   - Vulnerability ID: CVE-2020-15366
+   - Severity: MODERATE
+   - Description: Prototype Pollution in Ajv
+   - Published Date: 2022-02-10 23:30:59+00:00
+   - Version Range: < 6.12.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-15366
+ - `axios` (`1.7.5`)
+   - Vulnerability ID: CVE-2023-45857
+   - Severity: MODERATE
+   - Description: Axios Cross-Site Request Forgery Vulnerability
+   - Published Date: 2023-11-08 21:30:37+00:00
+   - Version Range: >= 0.8.1, < 0.28.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-45857
+ - `axios` (`1.7.5`)
+   - Vulnerability ID: CVE-2023-45857
+   - Severity: MODERATE
+   - Description: Axios Cross-Site Request Forgery Vulnerability
+   - Published Date: 2023-11-08 21:30:37+00:00
+   - Version Range: >= 1.0.0, < 1.6.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-45857
+ - `axios` (`1.7.5`)
+   - Vulnerability ID: CVE-2020-28168
+   - Severity: MODERATE
+   - Description: Axios vulnerable to Server-Side Request Forgery
+   - Published Date: 2021-01-04 20:59:40+00:00
+   - Version Range: < 0.21.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28168
+ - `browserslist` (`4.24.4`)
+   - Vulnerability ID: CVE-2021-23364
+   - Severity: MODERATE
+   - Description: Regular Expression Denial of Service in browserslist
+   - Published Date: 2021-05-24 19:52:40+00:00
+   - Version Range: >= 4.0.0, < 4.16.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23364
+ - `canvas` (`2.11.2`)
+   - Vulnerability ID: GHSA-vpq5-4rc8-c222
+   - Severity: MODERATE
+   - Description: Denial of Service in canvas
+   - Published Date: 2019-06-05 14:10:45+00:00
+   - Version Range: < 1.6.10
+   - Reference URL: https://github.com/Automattic/node-canvas/commit/c3e4ccb1c404da01e83fe5eb3626bf55f7f55957
+ - `yargs-parser` (`21.1.1`)
+   - Vulnerability ID: CVE-2020-7608
+   - Severity: MODERATE
+   - Description: yargs-parser Vulnerable to Prototype Pollution
+   - Published Date: 2020-09-04 18:00:54+00:00
+   - Version Range: >= 16.0.0, < 18.1.1
+   - Reference URL: https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
+ - `yargs-parser` (`21.1.1`)
+   - Vulnerability ID: CVE-2020-7608
+   - Severity: MODERATE
+   - Description: yargs-parser Vulnerable to Prototype Pollution
+   - Published Date: 2020-09-04 18:00:54+00:00
+   - Version Range: <= 5.0.0
+   - Reference URL: https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
+ - `yargs-parser` (`21.1.1`)
+   - Vulnerability ID: CVE-2020-7608
+   - Severity: MODERATE
+   - Description: yargs-parser Vulnerable to Prototype Pollution
+   - Published Date: 2020-09-04 18:00:54+00:00
+   - Version Range: >= 6.0.0, < 13.1.2
+   - Reference URL: https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
+ - `yargs-parser` (`21.1.1`)
+   - Vulnerability ID: CVE-2020-7608
+   - Severity: MODERATE
+   - Description: yargs-parser Vulnerable to Prototype Pollution
+   - Published Date: 2020-09-04 18:00:54+00:00
+   - Version Range: >= 14.0.0, < 15.0.1
+   - Reference URL: https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
+ - `zod` (`3.22.4`)
+   - Vulnerability ID: CVE-2023-4316
+   - Severity: MODERATE
+   - Description: Zod denial of service vulnerability
+   - Published Date: 2023-09-28 21:30:58+00:00
+   - Version Range: <= 3.22.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4316
+ - `tar` (`6.2.1`)
+   - Vulnerability ID: CVE-2024-28863
+   - Severity: MODERATE
+   - Description: Denial of service while parsing a tar file due to lack of folders count validation
+   - Published Date: 2024-03-22 16:57:05+00:00
+   - Version Range: < 6.2.1
+   - Reference URL: https://github.com/isaacs/node-tar/security/advisories/GHSA-f5x3-32g6-xq36
+ - `uri-js` (`4.4.1`)
+   - Vulnerability ID: CVE-2017-16021
+   - Severity: MODERATE
+   - Description: Regular Expression Denial Of Service in uri-js
+   - Published Date: 2018-07-24 20:00:30+00:00
+   - Version Range: < 3.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-16021
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-46565
+   - Severity: MODERATE
+   - Description: Vite's server.fs.deny bypassed with /. for files under project root
+   - Published Date: 2025-04-30 17:40:27+00:00
+   - Version Range: <= 4.5.13
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-859w-5945-r5v3
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-46565
+   - Severity: MODERATE
+   - Description: Vite's server.fs.deny bypassed with /. for files under project root
+   - Published Date: 2025-04-30 17:40:27+00:00
+   - Version Range: >= 5.0.0, <= 5.4.18
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-859w-5945-r5v3
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-46565
+   - Severity: MODERATE
+   - Description: Vite's server.fs.deny bypassed with /. for files under project root
+   - Published Date: 2025-04-30 17:40:27+00:00
+   - Version Range: >= 6.0.0, <= 6.1.5
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-859w-5945-r5v3
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-46565
+   - Severity: MODERATE
+   - Description: Vite's server.fs.deny bypassed with /. for files under project root
+   - Published Date: 2025-04-30 17:40:27+00:00
+   - Version Range: >= 6.2.0, <= 6.2.6
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-859w-5945-r5v3
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-46565
+   - Severity: MODERATE
+   - Description: Vite's server.fs.deny bypassed with /. for files under project root
+   - Published Date: 2025-04-30 17:40:27+00:00
+   - Version Range: >= 6.3.0, <= 6.3.3
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-859w-5945-r5v3
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-32395
+   - Severity: MODERATE
+   - Description: Vite has an `server.fs.deny` bypass with an invalid `request-target`
+   - Published Date: 2025-04-11 14:06:03+00:00
+   - Version Range: < 4.5.13
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-32395
+   - Severity: MODERATE
+   - Description: Vite has an `server.fs.deny` bypass with an invalid `request-target`
+   - Published Date: 2025-04-11 14:06:03+00:00
+   - Version Range: >= 5.0.0, < 5.4.18
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-32395
+   - Severity: MODERATE
+   - Description: Vite has an `server.fs.deny` bypass with an invalid `request-target`
+   - Published Date: 2025-04-11 14:06:03+00:00
+   - Version Range: >= 6.0.0, < 6.0.15
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-32395
+   - Severity: MODERATE
+   - Description: Vite has an `server.fs.deny` bypass with an invalid `request-target`
+   - Published Date: 2025-04-11 14:06:03+00:00
+   - Version Range: >= 6.1.0, < 6.1.5
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4
+ - `vite` (`5.2.9`)
+   - Vulnerability ID: CVE-2025-32395
+   - Severity: MODERATE
+   - Description: Vite has an `server.fs.deny` bypass with an invalid `request-target`
+   - Published Date: 2025-04-11 14:06:03+00:00
+   - Version Range: >= 6.2.0, < 6.2.6
+   - Reference URL: https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4
+ - `word-wrap` (`1.2.5`)
+   - Vulnerability ID: CVE-2023-26115
+   - Severity: MODERATE
+   - Description: word-wrap vulnerable to Regular Expression Denial of Service
+   - Published Date: 2023-06-22 06:30:18+00:00
+   - Version Range: < 1.2.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26115
+ - `xlsx` (`0.18.5`)
+   - Vulnerability ID: CVE-2021-32014
+   - Severity: MODERATE
+   - Description: Denial of Service in SheetJS Pro
+   - Published Date: 2021-07-22 19:47:15+00:00
+   - Version Range: < 0.17.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-32014
+ - `xlsx` (`0.18.5`)
+   - Vulnerability ID: CVE-2021-32012
+   - Severity: MODERATE
+   - Description: Denial of Service in SheetJS Pro
+   - Published Date: 2021-07-22 19:48:17+00:00
+   - Version Range: < 0.17.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-32012
+ - `xlsx` (`0.18.5`)
+   - Vulnerability ID: CVE-2021-32013
+   - Severity: MODERATE
+   - Description: Denial of Service in SheetsJS Pro
+   - Published Date: 2021-07-22 19:48:13+00:00
+   - Version Range: < 0.17.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-32013
+ - `postcss` (`8.4.38`)
+   - Vulnerability ID: CVE-2023-44270
+   - Severity: MODERATE
+   - Description: PostCSS line return parsing error
+   - Published Date: 2023-09-30 00:31:10+00:00
+   - Version Range: < 8.4.31
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44270
+ - `postcss` (`8.4.38`)
+   - Vulnerability ID: CVE-2021-23382
+   - Severity: MODERATE
+   - Description: Regular Expression Denial of Service in postcss
+   - Published Date: 2022-01-07 00:21:36+00:00
+   - Version Range: < 7.0.36
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23382
+ - `postcss` (`8.4.38`)
+   - Vulnerability ID: CVE-2021-23382
+   - Severity: MODERATE
+   - Description: Regular Expression Denial of Service in postcss
+   - Published Date: 2022-01-07 00:21:36+00:00
+   - Version Range: >= 8.0.0, < 8.2.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23382
+ - `postcss` (`8.4.38`)
+   - Vulnerability ID: CVE-2021-23368
+   - Severity: MODERATE
+   - Description: Regular Expression Denial of Service in postcss
+   - Published Date: 2021-05-10 15:29:24+00:00
+   - Version Range: >= 8.0.0, < 8.2.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23368
+ - `postcss` (`8.4.38`)
+   - Vulnerability ID: CVE-2021-23368
+   - Severity: MODERATE
+   - Description: Regular Expression Denial of Service in postcss
+   - Published Date: 2021-05-10 15:29:24+00:00
+   - Version Range: >= 7.0.0, < 7.0.36
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-23368
+ - `react` (`18.3.1`)
+   - Vulnerability ID: CVE-2013-7035
+   - Severity: MODERATE
+   - Description: Cross-Site Scripting in react
+   - Published Date: 2020-09-04 16:52:57+00:00
+   - Version Range: >= 0.5.0, < 0.5.2
+   - Reference URL: https://reactjs.org/blog/2013/12/18/react-v0.5.2-v0.4.2.html
+ - `react` (`18.3.1`)
+   - Vulnerability ID: CVE-2013-7035
+   - Severity: MODERATE
+   - Description: Cross-Site Scripting in react
+   - Published Date: 2020-09-04 16:52:57+00:00
+   - Version Range: >= 0.4.0, < 0.4.2
+   - Reference URL: https://reactjs.org/blog/2013/12/18/react-v0.5.2-v0.4.2.html
+ - `react-dom` (`18.2.0`)
+   - Vulnerability ID: CVE-2018-6341
+   - Severity: MODERATE
+   - Description: Cross-Site Scripting in react-dom
+   - Published Date: 2019-01-04 19:05:35+00:00
+   - Version Range: >= 16.4.0, < 16.4.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-6341
+ - `react-dom` (`18.2.0`)
+   - Vulnerability ID: CVE-2018-6341
+   - Severity: MODERATE
+   - Description: Cross-Site Scripting in react-dom
+   - Published Date: 2019-01-04 19:05:35+00:00
+   - Version Range: >= 16.3.0, < 16.3.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-6341
+ - `react-dom` (`18.2.0`)
+   - Vulnerability ID: CVE-2018-6341
+   - Severity: MODERATE
+   - Description: Cross-Site Scripting in react-dom
+   - Published Date: 2019-01-04 19:05:35+00:00
+   - Version Range: = 16.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-6341
+ - `react-dom` (`18.2.0`)
+   - Vulnerability ID: CVE-2018-6341
+   - Severity: MODERATE
+   - Description: Cross-Site Scripting in react-dom
+   - Published Date: 2019-01-04 19:05:35+00:00
+   - Version Range: >= 16.1.0, < 16.1.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-6341
+ - `react-dom` (`18.2.0`)
+   - Vulnerability ID: CVE-2018-6341
+   - Severity: MODERATE
+   - Description: Cross-Site Scripting in react-dom
+   - Published Date: 2019-01-04 19:05:35+00:00
+   - Version Range: = 16.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-6341
+### Low Vulnerabilities (Monitor)
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 4.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 3.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 1.0.0, <= 1.1.11
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 2.0.0, <= 2.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `cookie` (`0.6.0`)
+   - Vulnerability ID: CVE-2024-47764
+   - Severity: LOW
+   - Description: cookie accepts cookie name, path, and domain with out of bounds characters
+   - Published Date: 2024-10-04 20:31:00+00:00
+   - Version Range: < 0.7.0
+   - Reference URL: https://github.com/jshttp/cookie/security/advisories/GHSA-pxg6-pf52-xh8x
+ - `debug` (`4.3.4`)
+   - Vulnerability ID: CVE-2017-16137
+   - Severity: LOW
+   - Description: Regular Expression Denial of Service in debug
+   - Published Date: 2018-08-09 20:18:07+00:00
+   - Version Range: >= 4.0.0, < 4.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-16137
+ - `debug` (`4.3.4`)
+   - Vulnerability ID: CVE-2017-16137
+   - Severity: LOW
+   - Description: Regular Expression Denial of Service in debug
+   - Published Date: 2018-08-09 20:18:07+00:00
+   - Version Range: >= 3.2.0, < 3.2.7
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-16137
+ - `debug` (`4.3.4`)
+   - Vulnerability ID: CVE-2017-16137
+   - Severity: LOW
+   - Description: Regular Expression Denial of Service in debug
+   - Published Date: 2018-08-09 20:18:07+00:00
+   - Version Range: >= 3.0.0, < 3.1.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-16137
+ - `debug` (`4.3.4`)
+   - Vulnerability ID: CVE-2017-16137
+   - Severity: LOW
+   - Description: Regular Expression Denial of Service in debug
+   - Published Date: 2018-08-09 20:18:07+00:00
+   - Version Range: < 2.6.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-16137
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 4.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 3.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 1.0.0, <= 1.1.11
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 2.0.0, <= 2.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 4.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 3.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 1.0.0, <= 1.1.11
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 2.0.0, <= 2.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 4.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 3.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 1.0.0, <= 1.1.11
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`1.1.11`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 2.0.0, <= 2.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `node-fetch` (`2.7.0`)
+   - Vulnerability ID: CVE-2020-15168
+   - Severity: LOW
+   - Description: The `size` option isn't honored after following a redirect in node-fetch
+   - Published Date: 2020-09-10 17:46:21+00:00
+   - Version Range: >= 2.0.0, < 2.6.1
+   - Reference URL: https://github.com/node-fetch/node-fetch/security/advisories/GHSA-w7rc-rwvf-8q5r
+ - `node-fetch` (`2.7.0`)
+   - Vulnerability ID: CVE-2020-15168
+   - Severity: LOW
+   - Description: The `size` option isn't honored after following a redirect in node-fetch
+   - Published Date: 2020-09-10 17:46:21+00:00
+   - Version Range: >= 3.0.0-beta.1, <= 3.0.0-beta.8
+   - Reference URL: https://github.com/node-fetch/node-fetch/security/advisories/GHSA-w7rc-rwvf-8q5r
+ - `brace-expansion` (`2.0.1`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 4.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`2.0.1`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: = 3.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`2.0.1`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 1.0.0, <= 1.1.11
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `brace-expansion` (`2.0.1`)
+   - Vulnerability ID: CVE-2025-5889
+   - Severity: LOW
+   - Description: brace-expansion Regular Expression Denial of Service vulnerability
+   - Published Date: 2025-06-09 21:30:51+00:00
+   - Version Range: >= 2.0.0, <= 2.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2025-5889
+ - `braces` (`3.0.3`)
+   - Vulnerability ID: CVE-2018-1109
+   - Severity: LOW
+   - Description: Regular Expression Denial of Service (ReDoS) in braces
+   - Published Date: 2022-01-06 20:42:03+00:00
+   - Version Range: < 2.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-1109
+ - `braces` (`3.0.3`)
+   - Vulnerability ID: GHSA-g95f-p29q-9xw4
+   - Severity: LOW
+   - Description: Regular Expression Denial of Service in braces
+   - Published Date: 2019-06-06 15:30:30+00:00
+   - Version Range: < 2.3.1
+   - Reference URL: https://github.com/micromatch/braces/commit/abdafb0cae1e0c00f184abbadc692f4eaa98f451
+ - `chownr` (`2.0.0`)
+   - Vulnerability ID: CVE-2017-18869
+   - Severity: LOW
+   - Description: Time-of-check Time-of-use (TOCTOU) Race Condition in chownr
+   - Published Date: 2022-02-10 23:33:39+00:00
+   - Version Range: < 1.1.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-18869
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/e2e-tests`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `fsevents` (`2.3.2`)
+   - Vulnerability ID: CVE-2023-45311
+   - Severity: CRITICAL
+   - Description: Code injection in fsevents
+   - Published Date: 2023-10-06 21:30:49+00:00
+   - Version Range: <= 1.2.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-45311
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/inference/.smi-image/lpf-prod-image`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - `gunicorn` (`22.0.0`)
+   - Vulnerability ID: CVE-2024-6827
+   - Severity: HIGH
+   - Description: Gunicorn HTTP Request/Response Smuggling vulnerability
+   - Published Date: 2025-03-20 12:32:45+00:00
+   - Version Range: < 23.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-6827
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.8-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/prod/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/inference/.smi-image/lpf-prod-image`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - `gunicorn` (`22.0.0`)
+   - Vulnerability ID: CVE-2024-6827
+   - Severity: HIGH
+   - Description: Gunicorn HTTP Request/Response Smuggling vulnerability
+   - Published Date: 2025-03-20 12:32:45+00:00
+   - Version Range: < 23.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-6827
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/inference/.smi-image/lpf-live-image`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - `gunicorn` (`22.0.0`)
+   - Vulnerability ID: CVE-2024-6827
+   - Severity: HIGH
+   - Description: Gunicorn HTTP Request/Response Smuggling vulnerability
+   - Published Date: 2025-03-20 12:32:45+00:00
+   - Version Range: < 23.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-6827
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.8-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/live/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/inference/.smi-image/lpf-dev-image`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - `gunicorn` (`22.0.0`)
+   - Vulnerability ID: CVE-2024-6827
+   - Severity: HIGH
+   - Description: Gunicorn HTTP Request/Response Smuggling vulnerability
+   - Published Date: 2025-03-20 12:32:45+00:00
+   - Version Range: < 23.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-6827
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.8-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_processor/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_processor_eventbridge.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/dev/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/inference/.terraform/modules/smi_inference.smi_endpoints.smi_scheduling.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/inference/.terraform/modules/smi_inference.smi_scheduling.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/inference/.smi-image/lpf-stg-image`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - `gunicorn` (`22.0.0`)
+   - Vulnerability ID: CVE-2024-6827
+   - Severity: HIGH
+   - Description: Gunicorn HTTP Request/Response Smuggling vulnerability
+   - Published Date: 2025-03-20 12:32:45+00:00
+   - Version Range: < 23.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-6827
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/notify_slack.lambda/examples/fixtures/python3.8-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/main_service.serverless_app/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/env/stg/main/.terraform/modules/main_service.batch_weekly_usage.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/modules/inference/schedule`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pyyaml` (``)
+   - Vulnerability ID: CVE-2020-1747
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in PyYAML
+   - Published Date: 2021-04-20 16:14:24+00:00
+   - Version Range: >= 5.1b7, < 5.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-1747
+ - `pyyaml` (``)
+   - Vulnerability ID: CVE-2020-14343
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in PyYAML
+   - Published Date: 2021-03-25 21:26:26+00:00
+   - Version Range: < 5.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-14343
+ - `pyyaml` (``)
+   - Vulnerability ID: CVE-2017-18342
+   - Severity: CRITICAL
+   - Description: PyYAML insecurely deserializes YAML strings leading to arbitrary code execution
+   - Published Date: 2019-01-04 17:45:26+00:00
+   - Version Range: < 4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-18342
+ - `pyyaml` (``)
+   - Vulnerability ID: CVE-2019-20477
+   - Severity: CRITICAL
+   - Description: Deserialization of Untrusted Data in PyYAML
+   - Published Date: 2021-04-20 16:40:42+00:00
+   - Version Range: >= 5.1, < 5.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-20477
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/modules/inference/.terraform/modules/smi_scheduling.lambda/examples/fixtures/python-app1`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/terraform/modules/inference/modules/sagemaker-image/scratch-sm-image`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - `gunicorn` (`22.0.0`)
+   - Vulnerability ID: CVE-2024-6827
+   - Severity: HIGH
+   - Description: Gunicorn HTTP Request/Response Smuggling vulnerability
+   - Published Date: 2025-03-20 12:32:45+00:00
+   - Version Range: < 23.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-6827
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/artifacts/direct-item-code-recognition_202504240811.tar/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+ - `httpx` (`0.28.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41945
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in httpx
+   - Published Date: 2022-04-29 00:00:25+00:00
+   - Version Range: < 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41945
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+ - `pygments` (`2.19.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.6.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.15.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+### High Vulnerabilities (Action Recommended)
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `certifi` (`2024.12.14 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-37920
+   - Severity: HIGH
+   - Description: Removal of e-Tugra root certificate
+   - Published Date: 2023-07-25 14:43:53+00:00
+   - Version Range: >= 2015.4.28, < 2023.7.22
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-xqr8-7jwr-rhp7
+ - `fonttools` (`4.55.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+ - `pygments` (`2.19.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.19.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.6.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.15.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `tqdm` (`4.67.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.67.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+### Moderate Vulnerabilities (Review Recommended)
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `certifi` (`2024.12.14 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-23491
+   - Severity: MODERATE
+   - Description: Certifi removing TrustCor root certificate
+   - Published Date: 2022-12-07 23:05:18+00:00
+   - Version Range: >= 2017.11.05, < 2022.12.07
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-43fp-rhv2-5gv8
+ - `idna` (`3.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.19.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.6.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.15.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+### Low Vulnerabilities (Monitor)
+ - `certifi` (`2024.12.14 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+ - `tqdm` (`4.67.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-34062
+   - Severity: LOW
+   - Description: tqdm CLI arguments injection attack
+   - Published Date: 2024-05-03 19:33:28+00:00
+   - Version Range: >= 4.4.0, < 4.66.3
+   - Reference URL: https://github.com/tqdm/tqdm/security/advisories/GHSA-g7vv-2v7x-gj9p
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/artifacts/text-recognition_202503121612.tar/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.5.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.13.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+ - `h11` (`0.14.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+ - `httpx` (`0.27.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41945
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in httpx
+   - Published Date: 2022-04-29 00:00:25+00:00
+   - Version Range: < 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41945
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+### High Vulnerabilities (Action Recommended)
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.5.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.13.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-37920
+   - Severity: HIGH
+   - Description: Removal of e-Tugra root certificate
+   - Published Date: 2023-07-25 14:43:53+00:00
+   - Version Range: >= 2015.4.28, < 2023.7.22
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-xqr8-7jwr-rhp7
+ - `fonttools` (`4.52.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+### Moderate Vulnerabilities (Review Recommended)
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.5.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.13.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-23491
+   - Severity: MODERATE
+   - Description: Certifi removing TrustCor root certificate
+   - Published Date: 2022-12-07 23:05:18+00:00
+   - Version Range: >= 2017.11.05, < 2022.12.07
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-43fp-rhv2-5gv8
+ - `idna` (`3.7 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+### Low Vulnerabilities (Monitor)
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-34062
+   - Severity: LOW
+   - Description: tqdm CLI arguments injection attack
+   - Published Date: 2024-05-03 19:33:28+00:00
+   - Version Range: >= 4.4.0, < 4.66.3
+   - Reference URL: https://github.com/tqdm/tqdm/security/advisories/GHSA-g7vv-2v7x-gj9p
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/extract-pdf-specification/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+### High Vulnerabilities (Action Recommended)
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `fonttools` (`4.51.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+### Moderate Vulnerabilities (Review Recommended)
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `idna` (`3.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+### Low Vulnerabilities (Monitor)
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/predict-drawing-pages/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+ - `h11` (`0.14.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+ - `httpx` (`0.27.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41945
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in httpx
+   - Published Date: 2022-04-29 00:00:25+00:00
+   - Version Range: < 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41945
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+### High Vulnerabilities (Action Recommended)
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-37920
+   - Severity: HIGH
+   - Description: Removal of e-Tugra root certificate
+   - Published Date: 2023-07-25 14:43:53+00:00
+   - Version Range: >= 2015.4.28, < 2023.7.22
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-xqr8-7jwr-rhp7
+ - `fonttools` (`4.51.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+### Moderate Vulnerabilities (Review Recommended)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-23491
+   - Severity: MODERATE
+   - Description: Certifi removing TrustCor root certificate
+   - Published Date: 2022-12-07 23:05:18+00:00
+   - Version Range: >= 2017.11.05, < 2022.12.07
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-43fp-rhv2-5gv8
+ - `idna` (`3.7 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+### Low Vulnerabilities (Monitor)
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-34062
+   - Severity: LOW
+   - Description: tqdm CLI arguments injection attack
+   - Published Date: 2024-05-03 19:33:28+00:00
+   - Version Range: >= 4.4.0, < 4.66.3
+   - Reference URL: https://github.com/tqdm/tqdm/security/advisories/GHSA-g7vv-2v7x-gj9p
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/text-recognition/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+ - `httpx` (`0.27.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41945
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in httpx
+   - Published Date: 2022-04-29 00:00:25+00:00
+   - Version Range: < 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41945
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.5.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.13.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+### High Vulnerabilities (Action Recommended)
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-37920
+   - Severity: HIGH
+   - Description: Removal of e-Tugra root certificate
+   - Published Date: 2023-07-25 14:43:53+00:00
+   - Version Range: >= 2015.4.28, < 2023.7.22
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-xqr8-7jwr-rhp7
+ - `fonttools` (`4.52.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.5.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.13.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+### Moderate Vulnerabilities (Review Recommended)
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-23491
+   - Severity: MODERATE
+   - Description: Certifi removing TrustCor root certificate
+   - Published Date: 2022-12-07 23:05:18+00:00
+   - Version Range: >= 2017.11.05, < 2022.12.07
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-43fp-rhv2-5gv8
+ - `idna` (`3.7 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.5.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.13.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+### Low Vulnerabilities (Monitor)
+ - `certifi` (`2024.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+ - `tqdm` (`4.66.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-34062
+   - Severity: LOW
+   - Description: tqdm CLI arguments injection attack
+   - Published Date: 2024-05-03 19:33:28+00:00
+   - Version Range: >= 4.4.0, < 4.66.3
+   - Reference URL: https://github.com/tqdm/tqdm/security/advisories/GHSA-g7vv-2v7x-gj9p
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/cell-recognition/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `pyyaml` (`6.0.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-1747
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in PyYAML
+   - Published Date: 2021-04-20 16:14:24+00:00
+   - Version Range: >= 5.1b7, < 5.3.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-1747
+ - `pyyaml` (`6.0.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-14343
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in PyYAML
+   - Published Date: 2021-03-25 21:26:26+00:00
+   - Version Range: < 5.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-14343
+ - `pyyaml` (`6.0.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-18342
+   - Severity: CRITICAL
+   - Description: PyYAML insecurely deserializes YAML strings leading to arbitrary code execution
+   - Published Date: 2019-01-04 17:45:26+00:00
+   - Version Range: < 4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-18342
+ - `pyyaml` (`6.0.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-20477
+   - Severity: CRITICAL
+   - Description: Deserialization of Untrusted Data in PyYAML
+   - Published Date: 2021-04-20 16:40:42+00:00
+   - Version Range: >= 5.1, < 5.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-20477
+ - `scikit-learn` (`1.5.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.14.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+### High Vulnerabilities (Action Recommended)
+ - `psutil` (`6.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-18874
+   - Severity: HIGH
+   - Description: Double Free in psutil
+   - Published Date: 2020-03-12 17:02:50+00:00
+   - Version Range: <= 5.6.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-18874
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.5.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.14.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `fonttools` (`4.54.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+### Moderate Vulnerabilities (Review Recommended)
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.5.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.14.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.9.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `idna` (`3.7 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+### Low Vulnerabilities (Monitor)
+ - `ipython` (`8.29.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/direct-item-code-recognition/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `h11` (`0.14.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2025-43859
+   - Severity: CRITICAL
+   - Description: h11 accepts some malformed Chunked-Encoding bodies
+   - Published Date: 2025-04-24 16:07:56+00:00
+   - Version Range: < 0.16.0
+   - Reference URL: https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
+ - `httpx` (`0.27.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41945
+   - Severity: CRITICAL
+   - Description: Improper Input Validation in httpx
+   - Published Date: 2022-04-29 00:00:25+00:00
+   - Version Range: < 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41945
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+ - `pygments` (`2.19.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.6.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.15.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+### High Vulnerabilities (Action Recommended)
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `certifi` (`2024.12.14 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-37920
+   - Severity: HIGH
+   - Description: Removal of e-Tugra root certificate
+   - Published Date: 2023-07-25 14:43:53+00:00
+   - Version Range: >= 2015.4.28, < 2023.7.22
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-xqr8-7jwr-rhp7
+ - `fonttools` (`4.55.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+ - `pygments` (`2.19.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.19.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.6.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.15.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `tqdm` (`4.67.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `tqdm` (`4.67.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-10075
+   - Severity: HIGH
+   - Description: TDQM Arbitrary Code Execution
+   - Published Date: 2022-05-14 02:19:48+00:00
+   - Version Range: = 4.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-10075
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+### Moderate Vulnerabilities (Review Recommended)
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.11.11 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `certifi` (`2024.12.14 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-23491
+   - Severity: MODERATE
+   - Description: Certifi removing TrustCor root certificate
+   - Published Date: 2022-12-07 23:05:18+00:00
+   - Version Range: >= 2017.11.05, < 2022.12.07
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-43fp-rhv2-5gv8
+ - `idna` (`3.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.10.0.84 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.4.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.10.5 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.19.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.6.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.15.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+### Low Vulnerabilities (Monitor)
+ - `certifi` (`2024.12.14 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-39689
+   - Severity: LOW
+   - Description: Certifi removes GLOBALTRUST root certificate
+   - Published Date: 2024-07-05 20:06:40+00:00
+   - Version Range: >= 2021.5.30, < 2024.7.4
+   - Reference URL: https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc
+ - `ipython` (`8.31.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+ - `tqdm` (`4.67.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-34062
+   - Severity: LOW
+   - Description: tqdm CLI arguments injection attack
+   - Published Date: 2024-05-03 19:33:28+00:00
+   - Version Range: >= 4.4.0, < 4.66.3
+   - Reference URL: https://github.com/tqdm/tqdm/security/advisories/GHSA-g7vv-2v7x-gj9p
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/appliance-style-classification/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+### High Vulnerabilities (Action Recommended)
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `fonttools` (`4.51.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+### Moderate Vulnerabilities (Review Recommended)
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `idna` (`3.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+### Low Vulnerabilities (Monitor)
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/text-label-classification/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+### High Vulnerabilities (Action Recommended)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `fonttools` (`4.51.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+### Moderate Vulnerabilities (Review Recommended)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `idna` (`3.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+### Low Vulnerabilities (Monitor)
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/figure-detection/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+### High Vulnerabilities (Action Recommended)
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `fonttools` (`4.51.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+### Moderate Vulnerabilities (Review Recommended)
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `idna` (`3.7 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+### Low Vulnerabilities (Monitor)
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/predict-candidate-item-codes/dist`
+### Critical Vulnerabilities (Immediate Action Required)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25289
+   - Severity: CRITICAL
+   - Description: Out of bounds write in Pillow
+   - Published Date: 2021-03-29 16:35:16+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25289
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-8557
+   - Severity: CRITICAL
+   - Description: Command Injection in Pygments
+   - Published Date: 2022-05-17 02:37:56+00:00
+   - Version Range: >= 1.2.2, < 2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-8557
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-13092
+   - Severity: CRITICAL
+   - Description: scikit-learn Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 17:17:59+00:00
+   - Version Range: <= 0.23.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-13092
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-29824
+   - Severity: CRITICAL
+   - Description: Withdrawn: Use after free in SciPy
+   - Published Date: 2023-07-06 21:30:28+00:00
+   - Version Range: < 1.8.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-29824
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-20060
+   - Severity: CRITICAL
+   - Description: Exposure of Sensitive Information to an Unauthorized Actor in urllib3
+   - Published Date: 2018-12-12 15:52:07+00:00
+   - Version Range: < 1.23
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
+ - `joblib` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21797
+   - Severity: CRITICAL
+   - Description: joblib vulnerable to arbitrary code execution
+   - Published Date: 2022-09-27 00:00:22+00:00
+   - Version Range: < 1.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-21797
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-6446
+   - Severity: CRITICAL
+   - Description: Numpy Deserialization of Untrusted Data
+   - Published Date: 2022-05-24 22:00:57+00:00
+   - Version Range: <= 1.16.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-6446
+### High Vulnerabilities (Action Recommended)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-44271
+   - Severity: HIGH
+   - Description: Pillow Denial of Service vulnerability
+   - Published Date: 2023-11-03 06:36:30+00:00
+   - Version Range: >= 0, < 10.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-44271
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-45199
+   - Severity: HIGH
+   - Description: Pillow subject to DoS via SAMPLESPERPIXEL tag
+   - Published Date: 2022-11-14 12:00:15+00:00
+   - Version Range: >= 9.2.0, < 9.3.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-45199
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25288
+   - Severity: HIGH
+   - Description: Pillow Out-of-bounds Read vulnerability
+   - Published Date: 2021-06-08 18:49:28+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25288
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25287
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2021-06-08 18:49:02+00:00
+   - Version Range: >= 2.4.0, < 8.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-25290
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in Pillow
+   - Published Date: 2021-03-29 16:35:36+00:00
+   - Version Range: >= 0, < 8.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-25290
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-2533
+   - Severity: HIGH
+   - Description: Pillow buffer overflow in ImagingPcdDecode
+   - Published Date: 2018-07-24 20:15:13+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-2533
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-27291
+   - Severity: HIGH
+   - Description: Pygments vulnerable to Regular Expression Denial of Service (ReDoS)
+   - Published Date: 2021-03-29 16:33:03+00:00
+   - Version Range: >= 1.1, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-27291
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-20270
+   - Severity: HIGH
+   - Description: Infinite Loop in Pygments
+   - Published Date: 2021-04-20 16:35:47+00:00
+   - Version Range: >= 1.5, < 2.7.4
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-20270
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2020-28975
+   - Severity: HIGH
+   - Description: scikit-learn Denial of Service
+   - Published Date: 2022-05-24 17:34:40+00:00
+   - Version Range: >= 0.23.2, < 1.0.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2020-28975
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2013-4251
+   - Severity: HIGH
+   - Description: SciPy creates insecure temporary directories
+   - Published Date: 2022-05-05 00:28:59+00:00
+   - Version Range: < 0.12.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2013-4251
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: < 1.26.17
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-43804
+   - Severity: HIGH
+   - Description: `Cookie` HTTP header isn't stripped on cross-origin redirects
+   - Published Date: 2023-10-02 23:27:05+00:00
+   - Version Range: >= 2.0.0, < 2.0.6
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-11324
+   - Severity: HIGH
+   - Description: Improper Certificate Validation in urllib3
+   - Published Date: 2019-04-19 16:55:10+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-30251
+   - Severity: HIGH
+   - Description: aiohttp vulnerable to Denial of Service when trying to parse malformed POST requests
+   - Published Date: 2024-05-03 17:29:54+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5m98-qgg9-wh84
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23334
+   - Severity: HIGH
+   - Description: aiohttp is vulnerable to directory traversal
+   - Published Date: 2024-01-29 22:31:03+00:00
+   - Version Range: >= 1.0.5, < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+ - `fonttools` (`4.51.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45139
+   - Severity: HIGH
+   - Description: fonttools XML External Entity Injection (XXE) Vulnerability
+   - Published Date: 2024-01-09 16:01:10+00:00
+   - Version Range: >= 4.28.2, < 4.43.0
+   - Reference URL: https://github.com/fonttools/fonttools/security/advisories/GHSA-6673-4983-2vx5
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 8.0.0, < 8.0.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 7.17.0, < 7.31.1
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: >= 6.0.0, < 7.16.3
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-21699
+   - Severity: HIGH
+   - Description: Execution with Unnecessary Privileges in ipython
+   - Published Date: 2022-01-21 18:55:30+00:00
+   - Version Range: < 5.11
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 3.0.0, < 3.2.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-5607
+   - Severity: HIGH
+   - Description: IPython vulnerable to cross site request forgery (CSRF)
+   - Published Date: 2022-05-17 00:35:13+00:00
+   - Version Range: >= 0.12, < 2.4.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-5607
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26303
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability
+   - Published Date: 2023-02-23 00:30:39+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26303
+ - `markdown-it-py` (`3.0.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-26302
+   - Severity: HIGH
+   - Description: markdown-it-py Denial of Service vulnerability in the command line interface
+   - Published Date: 2023-02-23 00:30:40+00:00
+   - Version Range: < 2.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-26302
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1859
+   - Severity: HIGH
+   - Description: Numpy arbitrary file write via symlink attack
+   - Published Date: 2022-05-14 01:08:34+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1859
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41495
+   - Severity: HIGH
+   - Description: NumPy NULL Pointer Dereference
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41495
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2014-1858
+   - Severity: HIGH
+   - Description: Arbitrary file write in NumPy
+   - Published Date: 2022-05-14 03:48:04+00:00
+   - Version Range: < 1.8.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2014-1858
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12852
+   - Severity: HIGH
+   - Description: Numpy missing input validation
+   - Published Date: 2022-05-13 01:42:46+00:00
+   - Version Range: < 1.13.3
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12852
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-qr4w-53vh-m672
+   - Severity: HIGH
+   - Description: opencv-python bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863
+   - Published Date: 2024-08-30 23:37:20+00:00
+   - Version Range: >= 0, < 4.8.1.78
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1516
+   - Severity: HIGH
+   - Description: Double Free in OpenCV
+   - Published Date: 2021-10-12 22:00:08+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1516
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12597
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:00:41+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12597
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12598
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:00:51+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12598
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12599
+   - Severity: HIGH
+   - Description: Out-of-bounds Read in OpenCV 
+   - Published Date: 2021-10-12 22:01:08+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12599
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12600
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:16+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12600
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12601
+   - Severity: HIGH
+   - Description: Improper Restriction of Operations within the Bounds of a Memory Buffer in OpenCV 
+   - Published Date: 2021-10-12 22:01:23+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12601
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12602
+   - Severity: HIGH
+   - Description: Denial of Service in OpenCV
+   - Published Date: 2021-10-12 22:01:34+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12602
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2017-12603
+   - Severity: HIGH
+   - Description: Out-of-bounds Write in OpenCV
+   - Published Date: 2021-10-12 22:01:44+00:00
+   - Version Range: <= 3.3.0.9
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2017-12603
+ - `parso` (`0.8.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2019-12760
+   - Severity: HIGH
+   - Description: Deserialization vulnerability exists in parso
+   - Published Date: 2019-06-13 16:12:57+00:00
+   - Version Range: <= 0.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2019-12760
+### Moderate Vulnerabilities (Review Recommended)
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22816
+   - Severity: MODERATE
+   - Description: Out-of-bounds Read in Pillow
+   - Published Date: 2022-01-12 20:07:41+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22816
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-22815
+   - Severity: MODERATE
+   - Description: Improper Initialization in Pillow
+   - Published Date: 2022-01-12 20:07:43+00:00
+   - Version Range: < 9.0.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-22815
+ - `pillow` (`10.3.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-0740
+   - Severity: MODERATE
+   - Description: Pillow Buffer overflow in ImagingLibTiffDecode
+   - Published Date: 2018-07-24 20:03:51+00:00
+   - Version Range: >= 0, < 3.1.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-0740
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.7, < 1.7.4
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: >= 1.8, < 1.8.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-29510
+   - Severity: MODERATE
+   - Description: Use of "infinity" as an input to datetime and date fields causes infinite loop in pydantic
+   - Published Date: 2021-05-13 20:23:17+00:00
+   - Version Range: < 1.6.2
+   - Reference URL: https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: < 1.10.13
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pydantic` (`2.7.1 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3772
+   - Severity: MODERATE
+   - Description: Pydantic regular expression denial of service
+   - Published Date: 2024-04-15 03:31:00+00:00
+   - Version Range: >= 2.0.0, < 2.4.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-3772
+ - `pygments` (`2.18.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2022-40896
+   - Severity: MODERATE
+   - Description: Pygments vulnerable to ReDoS
+   - Published Date: 2023-07-19 15:30:26+00:00
+   - Version Range: < 2.15.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2022-40896
+ - `scikit-learn` (`1.4.2 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-5206
+   - Severity: MODERATE
+   - Description: scikit-learn sensitive data leakage vulnerability
+   - Published Date: 2024-06-06 21:30:37+00:00
+   - Version Range: < 1.5.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2024-5206
+ - `scipy` (`1.13.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-25399
+   - Severity: MODERATE
+   - Description: Withdrawn: scipy memory leak vulnerability
+   - Published Date: 2023-07-05 18:30:44+00:00
+   - Version Range: < 1.10.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2023-25399
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: >= 2.0.0, < 2.2.2
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-37891
+   - Severity: MODERATE
+   - Description: urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects
+   - Published Date: 2024-06-17 21:37:20+00:00
+   - Version Range: < 1.26.19
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-9015
+   - Severity: MODERATE
+   - Description: Urllib3 Incorrect Certificate Validation
+   - Published Date: 2022-05-17 03:05:04+00:00
+   - Version Range: >= 1.17, <= 1.18
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-9015
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 0, < 1.26.18
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-45803
+   - Severity: MODERATE
+   - Description: urllib3's request body not stripped after redirect from 303 status changes request method to GET
+   - Published Date: 2023-10-17 20:15:25+00:00
+   - Version Range: >= 2.0.0, < 2.0.7
+   - Reference URL: https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4
+ - `urllib3` (`2.2.3 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2018-25091
+   - Severity: MODERATE
+   - Description: Authorization Header forwarded on redirect
+   - Published Date: 2023-10-15 21:30:26+00:00
+   - Version Range: < 1.24.2
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2018-25091
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-42367
+   - Severity: MODERATE
+   - Description: In aiohttp, compressed files as symlinks are not protected from path traversal
+   - Published Date: 2024-08-09 16:49:58+00:00
+   - Version Range: >= 3.10.0b1, < 3.10.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-jwhx-xcg6-8xhj
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52304
+   - Severity: MODERATE
+   - Description: aiohttp allows request smuggling due to incorrect parsing of chunk extensions
+   - Published Date: 2024-11-18 21:02:32+00:00
+   - Version Range: <= 3.10.10
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8495-4g3g-x7pr
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-52303
+   - Severity: MODERATE
+   - Description: aiohttp has a memory leak when middleware is enabled when requesting a resource with a non-allowed method
+   - Published Date: 2024-11-18 21:02:17+00:00
+   - Version Range: >= 3.10.6, < 3.10.11
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-27mf-ghqm-j3j8
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-27306
+   - Severity: MODERATE
+   - Description: aiohttp Cross-site Scripting vulnerability on index pages for static file handling
+   - Published Date: 2024-04-18 13:45:21+00:00
+   - Version Range: < 3.9.4
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-7gpw-8wmc-pm8g
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-23829
+   - Severity: MODERATE
+   - Description: aiohttp's HTTP parser (the python one, not llhttp) still overly lenient about separators
+   - Published Date: 2024-01-29 22:30:07+00:00
+   - Version Range: < 3.9.2
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-8qpw-xqxj-h4r2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49081
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via version
+   - Published Date: 2023-11-27 23:17:42+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-49082
+   - Severity: MODERATE
+   - Description: aiohttp's ClientSession is vulnerable to CRLF injection via method
+   - Published Date: 2023-11-27 23:17:24+00:00
+   - Version Range: < 3.9.0
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx
+ - `aiohttp` (`3.10.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: GHSA-pjjw-qhg8-p2p9
+   - Severity: MODERATE
+   - Description: aiohttp has vulnerable dependency that is vulnerable to request smuggling
+   - Published Date: 2023-11-27 23:15:38+00:00
+   - Version Range: < 3.8.6
+   - Reference URL: https://github.com/aio-libs/aiohttp/security/advisories/GHSA-pjjw-qhg8-p2p9
+ - `idna` (`3.10 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2024-3651
+   - Severity: MODERATE
+   - Description: Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode
+   - Published Date: 2024-04-11 21:32:40+00:00
+   - Version Range: < 3.7
+   - Reference URL: https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4706
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-17 00:36:05+00:00
+   - Version Range: >= 3.0.0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4706
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-6938
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in Jupyter Notebook
+   - Published Date: 2022-05-14 02:04:49+00:00
+   - Version Range: <= 3.2.1
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-6938
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2015-4707
+   - Severity: MODERATE
+   - Description: Improper Neutralization of Input During Web Page Generation in IPython
+   - Published Date: 2022-05-13 01:31:05+00:00
+   - Version Range: >= 0, < 3.2.0
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2015-4707
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-33430
+   - Severity: MODERATE
+   - Description: NumPy Buffer Overflow (Disputed)
+   - Published Date: 2022-01-07 00:09:39+00:00
+   - Version Range: >= 1.9.0, < 1.21
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-33430
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-34141
+   - Severity: MODERATE
+   - Description: Incorrect Comparison in NumPy
+   - Published Date: 2021-12-18 00:00:41+00:00
+   - Version Range: < 1.22
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-34141
+ - `numpy` (`1.26.4 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2021-41496
+   - Severity: MODERATE
+   - Description: Buffer Copy without Checking Size of Input in NumPy
+   - Published Date: 2022-02-08 00:00:56+00:00
+   - Version Range: <= 1.18.5
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2021-41496
+ - `opencv-python` (`4.9.0.80 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2016-1517
+   - Severity: MODERATE
+   - Description: Improper Input Validation in OpenCV
+   - Published Date: 2021-10-12 22:00:31+00:00
+   - Version Range: <= 3.3.0.10
+   - Reference URL: https://nvd.nist.gov/vuln/detail/CVE-2016-1517
+### Low Vulnerabilities (Monitor)
+ - `ipython` (`8.24.0 ; python_version >= "3.10" and python_version < "3.11`)
+   - Vulnerability ID: CVE-2023-24816
+   - Severity: LOW
+   - Description: IPython vulnerable to command injection via set_term_title
+   - Published Date: 2023-02-10 19:55:53+00:00
+   - Version Range: < 8.10.0
+   - Reference URL: https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.
+## `/Volumes/PRO-G40/Project/panasonic-light-pose-finder-service/inference/tasks/cell-recognition/forgekit`
+### Critical Vulnerabilities (Immediate Action Required)
+ - No vulnerabilities found.
+### High Vulnerabilities (Action Recommended)
+ - No vulnerabilities found.
+### Moderate Vulnerabilities (Review Recommended)
+ - No vulnerabilities found.
+### Low Vulnerabilities (Monitor)
+ - No vulnerabilities found.
+### Unknown Severity Vulnerabilities (Further Investigation Needed)
+ - No vulnerabilities found.


### PR DESCRIPTION
## Summary
- replace sqlite3-based license cache with aiosqlite for async operations
- drop typing.Optional in favor of PEP 604 unions
- declare aiosqlite as a project dependency

## Testing
- `ruff format pyproject.toml src/security_checker/checkers/licenses/_cache.py`
- `ruff check src/security_checker/checkers/licenses/_cache.py src/security_checker/checkers/licenses/_vendor_trait.py`
- `python -m py_compile src/security_checker/checkers/licenses/_cache.py src/security_checker/checkers/licenses/_vendor_trait.py`
- `pip install aiosqlite` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9664834c8832ab2845a0d18b7dc81